### PR TITLE
Bg subtract bug fix

### DIFF
--- a/src/htbam_analysis/stitching/background_images.py
+++ b/src/htbam_analysis/stitching/background_images.py
@@ -103,44 +103,35 @@ class BackgroundImages:
 
         logging.debug("Background Subtraction Complete")
 
-def walk_and_bg_subtract(self, path, index, channel, manual_exposure=None):
-        """
-        Walks a directory structure, find images to background subtract, and executes subtraction
+    def walk_and_bg_subtract(self, path, index, channel, manual_exposure=None):
+            """
+            Walks a directory structure, find images to background subtract, and executes subtraction
 
-        Arguments:
-            (str) path: path from hwere to walk
-            (str) index: arbitrary index to select background image
-            (str) channel: channel to select background image
+            Arguments:
+                (str) path: path from hwere to walk
+                (str) index: arbitrary index to select background image
+                (str) channel: channel to select background image
 
-        Returns:
-            None
+            Returns:
+                None
 
-        """
+            """
 
-        parse = lambda f: tuple(f.split(".")[0].split("_")[1:3] + [".".join(f.split(".")[0].split("_")[3:])])
+            parse = lambda f: tuple(f.split(".")[0].split("_")[1:3] + [".".join(f.split(".")[0].split("_")[3:])])
 
-        for root, dirs, files in os.walk(path):
-            if ("StitchedImages" in root) | ("Analysis" in root):
-                parsed_files = {
-                    parse(f): os.path.join(root, f) for f in files
-                }
+            for root, dirs, files in os.walk(path):
+                if ("StitchedImages" in root) | ("Analysis" in root):
+                    parsed_files = {
+                        parse(f): os.path.join(root, f) for f in files
+                    }
 
-                for params, file in parsed_files.items():
+                    for params, file in parsed_files.items():
 
-                    # exposure, channel, and features for image
-                    e, c, f = params
+                        # exposure, channel, and features for image
+                        e, c, f = params
 
-                    # check that the channel in the file handle matches that passed as an arg
-                    if c == channel:
-                        if manual_exposure:  # in case filenames corrupted
-                            e = manual_exposure
-                        self.subtract_background(file, index, channel, int(e))
-            if ("StitchedImages" in root) | ("Analysis" in root):
-                to_correct = {
-                    parse(f): os.path.join(root, f) for f in files if correctable(f)
-                }
-                for params, file in to_correct.items():
-                    exposure, channel, feature = params
-                    if manual_exposure:  # in case filenames corrupted
-                        exposure = manual_exposure
-                    self.subtract_background(file, index, channel, int(exposure))
+                        # check that the channel in the file handle matches that passed as an arg
+                        if c == channel:
+                            if manual_exposure:  # in case filenames corrupted
+                                e = manual_exposure
+                            self.subtract_background(file, index, channel, int(e))

--- a/src/htbam_analysis/stitching/background_images.py
+++ b/src/htbam_analysis/stitching/background_images.py
@@ -103,7 +103,7 @@ class BackgroundImages:
 
         logging.debug("Background Subtraction Complete")
 
-    def walk_and_bg_subtract(self, path, index, channel, manual_exposure=None):
+def walk_and_bg_subtract(self, path, index, channel, manual_exposure=None):
         """
         Walks a directory structure, find images to background subtract, and executes subtraction
 
@@ -117,15 +117,24 @@ class BackgroundImages:
 
         """
 
-        correctable = (
-            lambda f: (channel in f)
-            and ("StitchedImage" in f or "StitchedImg" in f)
-            and not ("BGSubtracted" in f)
-        )
-
         parse = lambda f: tuple(f.split(".")[0].split("_")[1:3] + [".".join(f.split(".")[0].split("_")[3:])])
 
         for root, dirs, files in os.walk(path):
+            if ("StitchedImages" in root) | ("Analysis" in root):
+                parsed_files = {
+                    parse(f): os.path.join(root, f) for f in files
+                }
+
+                for params, file in parsed_files.items():
+
+                    # exposure, channel, and features for image
+                    e, c, f = params
+
+                    # check that the channel in the file handle matches that passed as an arg
+                    if c == channel:
+                        if manual_exposure:  # in case filenames corrupted
+                            e = manual_exposure
+                        self.subtract_background(file, index, channel, int(e))
             if ("StitchedImages" in root) | ("Analysis" in root):
                 to_correct = {
                     parse(f): os.path.join(root, f) for f in files if correctable(f)


### PR DESCRIPTION
`walk_and_bg_subtract` accepts a `channel` argument. If a directory contains images taken with different channels (i.e. a binding experiment), the method will apply background subtraction to all images. Not a major issue, but was a little confusing/concerning when I first encountered this behavior.

I've tweaked the code a little bit to ensure that this doesn't happen. 