### PR TITLE
Exclude filenames that start with ._ from background subtraction

### DIFF
--- a/src/htbam_analysis/stitching/background_images.py
+++ b/src/htbam_analysis/stitching/background_images.py
@@ -121,6 +121,7 @@ class BackgroundImages:
             lambda f: (channel in f)
             and ("StitchedImage" in f or "StitchedImg" in f)
             and not ("BGSubtracted" in f)
+            and not (f.startswith("._"))
         )
 
         parse = lambda f: tuple(f.split(".")[0].split("_")[1:3] + [".".join(f.split(".")[0].split("_")[3:])])


### PR DESCRIPTION
Assuming that the parameter `f` passed to the `correctable` lambda function is always of type `String`, I added the simple check that it does not start with `._` which should be the simplest change to ignore ghost files during background subtraction. If there are other instances throughout the codebase where ghost files interrupt file walking, I did not seek them nor did I attempt to correct them.

This resolved my problem in https://github.com/pinneylab/htbam_analysis/issues/30