### PR TITLE
feature/fast-stitching

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,8 +53,8 @@ Done:
 1. Stream tiles: read, rotate, trim, paste into a pre-allocated canvas, and drop tiles (~one tile + one canvas peak for FF-off cut).
 2. Parallelize stitching across rasters with a memory-aware process pool (`n_workers` on `ImageStitcher.stitch_images`).
 3. In-place pasting during cut-stitch (shared `assemble_cut` kernel; no concat stack).
+4. Faster tile rotation via `cv2.warpAffine` (`rastering.rotate_image`).
 
 Down the line:
 1. Default source of truth for overlap parameter should come from `imaging.csv`, not auto-calculated. Additionally, overlap should really be considered as a per-image parameter (or at least a shared parameter across images taken with the same settings).
-2. faster rotation with cv2.warpAffine
-3. Prefetch + aggressive release + memmap/tiled writes
+2. Prefetch + aggressive release + memmap/tiled writes

--- a/src/mercury/stitching/__init__.py
+++ b/src/mercury/stitching/__init__.py
@@ -656,7 +656,67 @@ def backgroud_subtract(background_image: np.ndarray, target_image: np.ndarray) -
     
     return subtracted_clipped
 
-# TODO: implement image streaming / parallelism here as well
+
+# Per-process cache so each pool worker loads a given background once.
+_bg_image_cache: dict = {}
+
+
+def _get_cached_background(background_path: str) -> np.ndarray:
+    """Load a background image, caching within the current process."""
+    cached = _bg_image_cache.get(background_path)
+    if cached is None:
+        cached = io.imread(background_path)
+        _bg_image_cache[background_path] = cached
+    return cached
+
+
+def subtract_single_image(
+    background_path: Optional[str],
+    target_path: str,
+    outfile: str,
+) -> Tuple[bool, Optional[str]]:
+    """Subtract (or copy) a single stitched image to ``outfile``.
+
+    Args:
+        background_path: Absolute path to the background TIFF, or ``None`` to
+            copy the target unchanged (zero-array fallback).
+        target_path: Absolute path to the target TIFF.
+        outfile: Absolute path for the output TIFF.
+
+    Returns:
+        ``(True, None)`` on success, or ``(False, error_message)`` on failure.
+        Failed runs do not write ``outfile``.
+    """
+    try:
+        outfile_path = Path(outfile)
+        outfile_path.parent.mkdir(parents=True, exist_ok=True)
+
+        if background_path is None:
+            shutil.copy(target_path, outfile_path)
+            return True, None
+
+        background_image = _get_cached_background(background_path)
+        target_image = io.imread(target_path)
+        subtracted_image = backgroud_subtract(background_image, target_image)
+        io.imsave(outfile_path, subtracted_image, check_contrast=False)
+        return True, None
+    except Exception as e:
+        return False, str(e)
+
+
+def _estimate_bgsub_bytes_per_worker(sample_image_path: Path) -> int:
+    """Estimate peak RSS per bg-sub worker from on-disk sample size.
+
+    Covers background + target uint16 buffers plus float scratch (~6x file size).
+    """
+    try:
+        file_size = sample_image_path.stat().st_size
+    except OSError:
+        file_size = 0
+    # Floor so auto-sizing still works for tiny / missing samples.
+    return max(file_size * 6, 16 * 1024 * 1024)
+
+
 class BackgroundSubtractor:
     """Manages background image matching and subtraction across stitched image datasets.
 
@@ -714,8 +774,21 @@ class BackgroundSubtractor:
             background_images: List[Union[Path, str]],
             settings_to_match: List[str] = ['temp', 'hum','setup', 'dname', 'lightsource', 'channel', 'exposure', 'camera_mode', 'binning', 'nosepiece'],
             verbose: bool = True,
-            dry_run: bool = False
+            dry_run: bool = False,
+            n_workers: Optional[int] = None,
             ):
+        """Match backgrounds by acquisition settings and subtract across the dataset.
+
+        Args:
+            background_images: Absolute paths to stitched background TIFFs listed in
+                ``stitched_images.csv``.
+            settings_to_match: Metadata columns used to group images that share a
+                background.
+            verbose: Print per-image errors on failure.
+            dry_run: Build metadata without reading or writing images.
+            n_workers: Process pool size. ``None`` auto-sizes from CPU and ~50% RAM;
+                ``1`` forces serial subtraction.
+        """
 
         # input sanity check
         background_images = self._background_image_check(background_images)
@@ -730,64 +803,85 @@ class BackgroundSubtractor:
             print('Attempting background subtracting on images with the following settings:')
             print(' | '.join(['{}: {}'.format(setting, value) for setting, value in zip(settings_to_match, settings)]))
 
-            # make a target df
-            background_image = None
-            group['background_image'] = [background_image] * len(group)
-
-            # check if a unique background image can be found
+            group = group.copy()
+            background_path: Optional[Path] = None
             background_mask = group['image_path'].isin(background_images)
-    
+
             if sum(background_mask) == 0:
                 print('No background image found. Subtracting with zero array.')
-
+                group['background_image'] = None
             else:
-                # grab background image (should just be one row)
-                background_image_path = group[background_mask].iloc[0]['image_path']
-                background_image = io.imread(background_image_path)
-                print('Using {} as background image'.format(background_image_path))
-
-                # update dataframe
-                group = group.copy() # to stop pandas from complaining 
-                group['background_image'] = [background_image_path] * len(group)
+                background_path = group[background_mask].iloc[0]['image_path']
+                print('Using {} as background image'.format(background_path))
+                group['background_image'] = background_path
                 group = group[~background_mask]
+
+            group = group.reset_index(drop=True)
+            group['success'] = True
 
             # endregion
 
-            success_mask = np.ones(len(group), dtype=bool)
-            for i in tqdm(range(len(group)), desc='Running background subtraction.'):
+            if len(group) == 0:
+                print('0 / 0 images were successfully background subtracted')
+                print()
+                bgsub_data.append(group)
+                continue
 
+            jobs = []
+            for i in range(len(group)):
                 target_image_path = group['image_path'].iloc[i]
                 outfile = self._bgsub_images_path / target_image_path.relative_to(self._stitched_image_path)
                 outfile.parent.mkdir(parents=True, exist_ok=True)
+                bg_str = str(background_path) if background_path is not None else None
+                jobs.append((i, bg_str, str(target_image_path), str(outfile)))
 
-                if not dry_run:
+            bytes_per_worker = _estimate_bgsub_bytes_per_worker(group['image_path'].iloc[0])
+            if n_workers is None:
+                workers = _auto_n_workers(bytes_per_worker, n_jobs=len(jobs))
+            else:
+                workers = max(1, int(n_workers))
+                avail = _available_ram_bytes()
+                if avail is not None and workers * bytes_per_worker > avail * 0.5:
+                    print(
+                        f"Warning: n_workers={workers} may exceed ~50% available RAM "
+                        f"(est. {workers * bytes_per_worker / (1024**2):.0f} MB vs "
+                        f"{0.5 * avail / (1024**2):.0f} MB budget)."
+                    )
 
-                    if isinstance(background_image, np.ndarray):
-            
-                        try: 
-                            # subtract and save
-                            target_image = io.imread(target_image_path)
-                            subtracted_image = backgroud_subtract(background_image, target_image)
-                            io.imsave(outfile, subtracted_image, check_contrast=False)#, plugin="tifffile"
-
+            if dry_run:
+                pass
+            elif workers <= 1:
+                for i, bg_str, target_str, outfile_str in tqdm(jobs, desc='Running background subtraction.'):
+                    ok, err = subtract_single_image(bg_str, target_str, outfile_str)
+                    if not ok:
+                        group.loc[i, 'success'] = False
+                        if verbose:
+                            print(f"Error background subtracting {target_str}: {err}")
+            else:
+                print(
+                    f"Background subtracting {len(jobs)} images with n_workers={workers} "
+                    f"(est. {bytes_per_worker / (1024**2):.1f} MB/worker)."
+                )
+                with ProcessPoolExecutor(max_workers=workers) as executor:
+                    future_map = {
+                        executor.submit(subtract_single_image, bg_str, target_str, outfile_str): i
+                        for i, bg_str, target_str, outfile_str in jobs
+                    }
+                    for fut in tqdm(as_completed(future_map), total=len(future_map), desc='Running background subtraction.'):
+                        i = future_map[fut]
+                        try:
+                            ok, err = fut.result()
                         except Exception as e:
-                            # "subtract" a zero array
-                            # or in other words, just copy target image
-                            success_mask[i] = False
-                            shutil.copy(target_image_path, outfile)
+                            ok, err = False, str(e)
+                        if not ok:
+                            group.loc[i, 'success'] = False
                             if verbose:
-                                print(f"Error background subtracting {target_image_path}: {e}")
-                            
-                    else:
-                        # "subtract" a zero array
-                        # or in other words, just copy target image
-                        success_mask[i] = False
-                        shutil.copy(target_image_path, outfile)   
-                             
-            print("{successes} / {total} images were successfully background subtracted".format(successes=(success_mask).sum(), total=len(success_mask)))
+                                print(f"Error background subtracting {jobs[i][2]}: {err}")
+
+            print("{successes} / {total} images were successfully background subtracted".format(successes=int(group['success'].sum()), total=len(group)))
             print()
             # update failure rows
-            group.loc[~success_mask, 'background_image'] = None
+            group.loc[~group['success'], 'background_image'] = None
             bgsub_data.append(group)
 
         if not dry_run:

--- a/src/mercury/stitching/__init__.py
+++ b/src/mercury/stitching/__init__.py
@@ -10,6 +10,7 @@ __version__ = "1.3.0"
 
 import yaml
 import shutil
+import os
 import numpy as np
 import pandas as pd
 from tqdm import tqdm
@@ -19,6 +20,7 @@ from typing import Tuple, Union, List, Optional
 import matplotlib.pyplot as plt
 import warnings
 import fnmatch
+from concurrent.futures import ProcessPoolExecutor, as_completed
 
 # load config with defaults, if exists
 config_path = Path(__file__).parent / "config.yaml"
@@ -119,7 +121,7 @@ def stitch_single_raster(
     raster_params: rastering.RasterParams,
     stitched_image_path: Path,
     method: str = "cut",
-) -> Tuple[bool, Path, str]:
+) -> Tuple[bool, Path, Optional[str]]:
     """Process and stitch a single raster group of image tiles into a composite TIF file.
 
     Args:
@@ -129,25 +131,80 @@ def stitch_single_raster(
         method (str, optional): Stitching algorithm ('cut' or 'blend'). Default is 'cut'.
 
     Returns:
-        tuple[bool, Path, str]: Tuple containing:
+        tuple[bool, Path, str | None]: Tuple containing:
             - bool: Success status flag.
             - Path: Output stitched image file path.
-            - str: Error message string if failed, else None.
+            - str | None: Error message string if failed, else None.
     """
-    n_raster = int(raster_params.dims[0] * raster_params.dims[1])
-    assert len(raster) == n_raster
-    
-    # Create the raster and stitch
-    raster_obj = rastering.FlatRaster(
-        image_refs=raster,
-        params=raster_params
-    )
-    stitched_image = raster_obj.stitch(method=method)
-    
-    # Save the stitched image
-    io.imsave(stitched_image_path, stitched_image, check_contrast=False)
-        
-    return True, stitched_image_path, None
+    stitched_image_path = Path(stitched_image_path)
+    try:
+        n_raster = int(raster_params.dims[0] * raster_params.dims[1])
+        assert len(raster) == n_raster
+
+        raster_obj = rastering.FlatRaster(
+            image_refs=[str(p) for p in raster],
+            params=raster_params,
+        )
+        stitched_image = raster_obj.stitch(method=method)
+
+        stitched_image_path.parent.mkdir(parents=True, exist_ok=True)
+        io.imsave(stitched_image_path, stitched_image, check_contrast=False)
+
+        # Release large arrays promptly (helps serial loops and pool workers)
+        raster_obj._images = None
+        del stitched_image
+        del raster_obj
+
+        return True, stitched_image_path, None
+    except Exception as e:
+        return False, stitched_image_path, str(e)
+
+
+def _available_ram_bytes() -> Optional[int]:
+    """Best-effort available RAM in bytes (Linux sysconf), else None."""
+    try:
+        page_size = os.sysconf("SC_PAGE_SIZE")
+        avail_pages = os.sysconf("SC_AVPHYS_PAGES")
+        if page_size > 0 and avail_pages > 0:
+            return int(page_size) * int(avail_pages)
+    except (ValueError, OSError, AttributeError):
+        pass
+    return None
+
+
+def _estimate_bytes_per_worker(
+    tile_size: int,
+    max_cols: int,
+    max_rows: int,
+    max_overlap: float,
+    max_tiles: int,
+    any_auto_ff: bool,
+) -> int:
+    """Estimate peak RSS contribution per stitch worker (uint16 tiles/canvas)."""
+    margin = int(tile_size * max_overlap / 2)
+    retained = tile_size - 2 * margin
+    # canvas is (rows * retained, cols * retained)
+    canvas_bytes = max_rows * retained * max_cols * retained * 2
+    tile_bytes = tile_size * tile_size * 2
+    if any_auto_ff:
+        return canvas_bytes + max_tiles * tile_bytes
+    return canvas_bytes + tile_bytes
+
+
+def _auto_n_workers(
+    bytes_per_worker: int,
+    n_jobs: int,
+    ram_fraction: float = 0.5,
+) -> int:
+    """Choose process count from CPU count and a fraction of available RAM."""
+    cpu = os.cpu_count() or 1
+    if n_jobs <= 1:
+        return 1
+    avail = _available_ram_bytes()
+    if avail is None or bytes_per_worker <= 0:
+        return max(1, min(2, cpu, n_jobs))
+    by_ram = max(1, int((avail * ram_fraction) // bytes_per_worker))
+    return max(1, min(cpu, n_jobs, by_ram))
 
 
 class ImageStitcher:
@@ -174,7 +231,7 @@ class ImageStitcher:
         self.stitched_image_data = None
         self.setup = set(self.raster_data['setup'].tolist()).pop()
         
-    def load_raster_data() -> pd.DataFrame:
+    def load_raster_data(self) -> pd.DataFrame:
         """Loads and parses `imaging.csv` manifest data from root directory.
 
         Returns:
@@ -293,14 +350,18 @@ class ImageStitcher:
         raster_obj = rastering.FlatRaster(image_refs=raster, params=temp_params)
         return raster_obj.detect_rotation(search_range=search_range)
 
+    # TODO: consider implementing stitch_images as a dispatcher
+    # to appropriate serial or parallel method based on n_workers
+    # rotation and job extraction logic would be shared
     def stitch_images(self, 
         rotation: Optional[float] = None, 
         get_rotation_from: str = '*', 
         acqui_origin: Tuple[bool] = (True, False),
         method: str = "cut",
-        overlap: Optional[float] = 0.1,
+        auto_overlap: bool = False,
         get_overlap_from: str = '*',
-        rotation_method: str = "overlaps"
+        rotation_method: str = "overlaps",
+        n_workers: Optional[int] = None,
     ):
         """Stitches all tile rasters listed in `imaging.csv` manifest.
 
@@ -309,9 +370,11 @@ class ImageStitcher:
             get_rotation_from (str, optional): Pattern matching rasters for auto-rotation estimation.
             acqui_origin (tuple[bool], optional): Acquisition origin tuple (e.g., (True, False)).
             method (str, optional): Stitching algorithm ('cut' or 'blend'). Default is 'cut'.
-            overlap (float, optional): Tile overlap fraction (0 to 1).
+            auto_overlap (bool, optional): Reserved; auto-overlap detection is currently disabled.
             get_overlap_from (str, optional): Pattern matching rasters for auto-overlap estimation.
             rotation_method (str, optional): Auto-rotation method ('overlaps' or 'radon').
+            n_workers (int, optional): Process pool size. ``None`` auto-sizes from CPU and ~50% RAM;
+                ``1`` forces serial stitching.
         """
         assert isinstance(self.raster_data, pd.DataFrame), 'Raster data has not been set.'
 
@@ -352,65 +415,112 @@ class ImageStitcher:
             rotation = float(np.median(detected_rotations))
             print(f"Using optimal rotation: {rotation:.3f} degrees from matching rasters")
 
-        # Automatically calculate overlap if None is passed
-        if overlap is None:
-            matched_overlap_paths = [
-                gp for gp in grouped.groups.keys()
-                if fnmatch.fnmatch(gp.name, get_overlap_from) or 
-                   fnmatch.fnmatch(str(gp.relative_to(self._raw_images_path)), get_overlap_from)
-            ]
-            if not matched_overlap_paths:
-                raise ValueError(f"No raster groups matched the pattern '{get_overlap_from}' for overlap detection. Available groups: {[gp.name for gp in grouped.groups.keys()]}")
-            
-            detected_overlaps = []
-            for group_path in matched_overlap_paths:
-                print(f"Auto-detecting optimal overlap from raster: {group_path}")
-                try:
-                    df = grouped.get_group(group_path)
-                    overlap_csv, width, height, ff_correction = df[['raster_overlap', 'raster_width', 'raster_height', 'apply_ff_correction']].iloc[0]
-                    width, height = int(width), int(height)
-                    raster = df['image_path'].to_list()
-                    # Use a baseline guess of 0.1 to extract overlap strips
-                    temp_params = rastering.RasterParams(0.1, size=SIZE, acqui_ori=acqui_origin, rotation=rotation, dims=(width, height), auto_ff=ff_correction, ff_type='BaSiC')
-                    raster_obj = rastering.FlatRaster(image_refs=raster, params=temp_params)
-                    raster_obj.fetch_images()
-                    val = raster_obj.detect_overlap()
-                    print(f"Detected overlap for {group_path.name}: {val:.4f}")
-                    detected_overlaps.append(val)
-                except Exception as e:
-                    print(f"Warning: Failed to auto-detect overlap for {group_path.name}: {e}")
-            
-            if not detected_overlaps:
-                raise ValueError(f"Failed to auto-detect overlap from any matching raster group (pattern: '{get_overlap_from}').")
-                
-            overlap = float(np.median(detected_overlaps))
-            print(f"Using optimal overlap: {overlap:.4f} from matching rasters")
+        # Build job list in deterministic group order
+        jobs = []
+        max_cols = 1
+        max_rows = 1
+        max_overlap = 0.0
+        max_tiles = 1
+        any_auto_ff = False
+
+        for image_parent, df in grouped:
+            outpath = self._stitched_images_path / image_parent.relative_to(self._raw_images_path).with_suffix('.tif')
+            overlap, width, height, ff_correction = df[['raster_overlap', 'raster_width', 'raster_height', 'apply_ff_correction']].iloc[0]
+            width, height = int(width), int(height)
+            overlap = float(overlap)
+            ff_correction = bool(ff_correction)
+            raster = [str(p) for p in df['image_path'].to_list()]
+            params = rastering.RasterParams(
+                overlap,
+                size=SIZE,
+                acqui_ori=acqui_origin,
+                rotation=rotation,
+                dims=(width, height),
+                auto_ff=ff_correction,
+                ff_type='BaSiC',
+            )
+            meta_row = df.drop_duplicates(subset=['image_path_parent']).drop(columns=raster_headers)
+            jobs.append((image_parent, raster, params, outpath, meta_row))
+
+            max_cols = max(max_cols, width)
+            max_rows = max(max_rows, height)
+            max_overlap = max(max_overlap, overlap)
+            max_tiles = max(max_tiles, width * height)
+            any_auto_ff = any_auto_ff or ff_correction
+
+        bytes_per_worker = _estimate_bytes_per_worker(
+            SIZE, max_cols, max_rows, max_overlap, max_tiles, any_auto_ff
+        )
+        if n_workers is None:
+            workers = _auto_n_workers(bytes_per_worker, n_jobs=len(jobs))
+        else:
+            workers = max(1, int(n_workers))
+            avail = _available_ram_bytes()
+            if avail is not None and workers * bytes_per_worker > avail * 0.5:
+                print(
+                    f"Warning: n_workers={workers} may exceed ~50% available RAM "
+                    f"(est. {workers * bytes_per_worker / (1024**2):.0f} MB vs "
+                    f"{0.5 * avail / (1024**2):.0f} MB budget)."
+                )
+
+        print(
+            f"Stitching {len(jobs)} rasters with n_workers={workers} "
+            f"(est. {bytes_per_worker / (1024**2):.1f} MB/worker)."
+        )
 
         success_counter = 0
-        for image_parent, df in tqdm(grouped, desc='Stitching images.'):
+        results_by_parent = {}
 
-            try:
-                # format outpath and make sure directory to write it to exists
-                outpath = self._stitched_images_path / image_parent.relative_to(self._raw_images_path).with_suffix('.tif')
+        def _run_serial():
+            nonlocal success_counter
+            for image_parent, raster, params, outpath, meta_row in tqdm(jobs, desc='Stitching images.'):
+                outpath.parent.mkdir(parents=True, exist_ok=True)
+                ok, _, err = stitch_single_raster(raster, params, outpath, method=method)
+                if ok:
+                    row = meta_row.copy()
+                    row['image_path'] = outpath.relative_to(self._stitched_images_path)
+                    results_by_parent[image_parent] = row
+                    success_counter += 1
+                else:
+                    print('Failed stitching of {}: {}'.format(image_parent, err))
+
+        if workers <= 1:
+            _run_serial()
+        else:
+            # Ensure parent dirs exist before workers write
+            for _, _, _, outpath, _ in jobs:
                 outpath.parent.mkdir(parents=True, exist_ok=True)
 
-                # extract params, stitch image
-                overlap_csv, width, height, ff_correction = df[['raster_overlap', 'raster_width', 'raster_height', 'apply_ff_correction']].iloc[0]
-                width, height = int(width), int(height)
-                raster = df['image_path'].to_list()
-                params = rastering.RasterParams(overlap, size=SIZE, acqui_ori=acqui_origin, rotation=rotation, dims=(width, height), auto_ff=ff_correction, ff_type='BaSiC') 
-                stitch_single_raster(raster, params, outpath, method=method)
+            with ProcessPoolExecutor(max_workers=workers) as executor:
+                future_map = {
+                    executor.submit(
+                        stitch_single_raster, raster, params, outpath, method
+                    ): (image_parent, outpath, meta_row)
+                    for image_parent, raster, params, outpath, meta_row in jobs
+                }
+                for fut in tqdm(as_completed(future_map), total=len(future_map), desc='Stitching images.'):
+                    image_parent, outpath, meta_row = future_map[fut]
+                    try:
+                        ok, _, err = fut.result()
+                    except Exception as e:
+                        ok, err = False, str(e)
+                    if ok:
+                        row = meta_row.copy()
+                        row['image_path'] = outpath.relative_to(self._stitched_images_path)
+                        results_by_parent[image_parent] = row
+                        success_counter += 1
+                    else:
+                        print('Failed stitching of {}: {}'.format(image_parent, err))
 
-                # carry over metadata
-                row = df.drop_duplicates(subset=['image_path_parent']).drop(columns=raster_headers)
-                row['image_path'] = outpath.relative_to(self._stitched_images_path)
-                stitched_image_data.append(row)
-                success_counter += 1
+        print('Successfully stitched {} / {} images.'.format(success_counter, len(jobs)))
 
-            except Exception as e:
-                print('Failed stitching of {}: {}'.format(image_parent, e))
+        # Preserve deterministic group order in CSV
+        for image_parent, _, _, _, _ in jobs:
+            if image_parent in results_by_parent:
+                stitched_image_data.append(results_by_parent[image_parent])
 
-        print('Successfully stitched {} / {} images.'.format(success_counter, len(grouped)))
+        if not stitched_image_data:
+            raise RuntimeError("No rasters were successfully stitched.")
 
         self.stitched_image_data = pd.concat(stitched_image_data).reset_index(drop=True)
         self.stitched_image_data.to_csv(self._stitched_images_path / 'stitched_images.csv', index=False)
@@ -546,7 +656,7 @@ def backgroud_subtract(background_image: np.ndarray, target_image: np.ndarray) -
     
     return subtracted_clipped
 
-
+# TODO: implement image streaming / parallelism here as well
 class BackgroundSubtractor:
     """Manages background image matching and subtraction across stitched image datasets.
 

--- a/src/mercury/stitching/__init__.py
+++ b/src/mercury/stitching/__init__.py
@@ -787,7 +787,7 @@ class BackgroundSubtractor:
             print("{successes} / {total} images were successfully background subtracted".format(successes=(success_mask).sum(), total=len(success_mask)))
             print()
             # update failure rows
-            group.loc[~success_mask, 'column_name'] = None
+            group.loc[~success_mask, 'background_image'] = None
             bgsub_data.append(group)
 
         if not dry_run:

--- a/src/mercury/stitching/rastering.py
+++ b/src/mercury/stitching/rastering.py
@@ -1,7 +1,8 @@
 import numpy as np
 import pathlib
 import logging
-from skimage import io, transform
+import cv2
+from skimage import io
 from abc import abstractmethod, ABC
 from matplotlib import pyplot as plt
 from scipy.optimize import curve_fit
@@ -30,7 +31,12 @@ def ff_subtract(i, ffi, ff_bval, ff_scale):
 
 
 def rotate_image(img, rotation_val) -> np.array:
-    """Rotates an image array by a specified angle in degrees.
+    """Rotates an image array by a specified angle in degrees via ``cv2.warpAffine``.
+
+    Matches the historical skimage convention: positive angles are
+    counter-clockwise, output shape is unchanged, and out-of-bounds pixels
+    are filled with 0. The rotation center uses skimage's ``(cols-1)/2``,
+    ``(rows-1)/2`` convention for closer geometric agreement.
 
     Args:
         img (np.ndarray): Input image array.
@@ -39,8 +45,23 @@ def rotate_image(img, rotation_val) -> np.array:
     Returns:
         np.ndarray: Rotated uint16 image array.
     """
-    rotation_params = {"resize": False, "clip": True, "preserve_range": True}
-    return transform.rotate(img, rotation_val, **rotation_params).astype("uint16")
+    if not rotation_val:
+        return img.astype("uint16", copy=False)
+
+    rows, cols = img.shape[:2]
+    # skimage.transform.rotate center convention
+    center = ((cols - 1) / 2.0, (rows - 1) / 2.0)
+    matrix = cv2.getRotationMatrix2D(center, rotation_val, 1.0)
+    # Float warp + truncating cast mirrors prior skimage .astype("uint16") path
+    rotated = cv2.warpAffine(
+        img.astype(np.float32, copy=False),
+        matrix,
+        (cols, rows),
+        flags=cv2.INTER_LINEAR,
+        borderMode=cv2.BORDER_CONSTANT,
+        borderValue=0.0,
+    )
+    return rotated.astype("uint16")
 
 
 def iter_tiles(

--- a/src/mercury/stitching/rastering.py
+++ b/src/mercury/stitching/rastering.py
@@ -9,7 +9,7 @@ from scipy.ndimage import gaussian_filter
 from basicpy import BaSiC
 
 import os
-from typing import Tuple
+from typing import Iterable, Iterator, List, Optional, Tuple, Union
 
 
 def ff_subtract(i, ffi, ff_bval, ff_scale):
@@ -41,6 +41,99 @@ def rotate_image(img, rotation_val) -> np.array:
     """
     rotation_params = {"resize": False, "clip": True, "preserve_range": True}
     return transform.rotate(img, rotation_val, **rotation_params).astype("uint16")
+
+
+def iter_tiles(
+    refs: Iterable[Union[str, pathlib.Path]], rotation: float = 0.0
+) -> Iterator[Tuple[int, np.ndarray]]:
+    """Yield (index, tile) one at a time: read, optional rotate, then drop after yield."""
+    for i, ref in enumerate(refs):
+        img = io.imread(ref)
+        if rotation:
+            img = rotate_image(img, rotation)
+        yield i, img
+
+
+def load_tiles(
+    refs: Iterable[Union[str, pathlib.Path]], rotation: float = 0.0
+) -> List[np.ndarray]:
+    """Load (and optionally rotate) all tiles into a list."""
+    return [tile for _, tile in iter_tiles(refs, rotation)]
+
+
+def cut_margin_retained(size: int, overlap: float) -> Tuple[int, int, slice]:
+    """Return (margin, retained, border_slice) for cut-stitch trimming."""
+    if overlap < 0 or overlap >= 1:
+        raise ValueError("Overlap must be ≥ 0 and < 1")
+    margin = int(size * overlap / 2)
+    retained = size - 2 * margin
+    if margin == 0:
+        border = slice(0, None)
+    else:
+        border = slice(margin, -margin)
+    return margin, retained, border
+
+
+def grid_index(
+    i: int, dims: Tuple[int, int], acqui_ori: Tuple[bool, bool]
+) -> Tuple[int, int]:
+    """Map flat tile index to (col, row) after acquisition-origin flips.
+
+    Matches historical reshape+(flip axis 0/1)+concatenate geometry:
+    dims=(cols, rows); flat order is c * rows + r.
+    """
+    cols, rows = int(dims[0]), int(dims[1])
+    c = i // rows
+    r = i % rows
+    if acqui_ori[0]:
+        c = cols - 1 - c
+    if acqui_ori[1]:
+        r = rows - 1 - r
+    return c, r
+
+
+def paste_cut_tile(
+    canvas: np.ndarray,
+    tile: np.ndarray,
+    c: int,
+    r: int,
+    retained: int,
+    border: slice,
+) -> None:
+    """Trim tile borders and paste into the cut-stitch canvas in place.
+
+    Canvas layout matches historical concatenate: axis0 stacks rows, axis1 stacks cols,
+    so tile (c, r) lands at canvas[r*retained:(r+1)*retained, c*retained:(c+1)*retained].
+    """
+    y0 = r * retained
+    x0 = c * retained
+    canvas[y0 : y0 + retained, x0 : x0 + retained] = tile[border, border]
+
+
+def assemble_cut(
+    tile_iter: Iterable[Tuple[int, np.ndarray]],
+    dims: Tuple[int, int],
+    acqui_ori: Tuple[bool, bool],
+    overlap: float,
+    size: int,
+    dtype=None,
+) -> np.ndarray:
+    """Allocate a canvas and paste trimmed tiles from an (index, array) iterator."""
+    _, retained, border = cut_margin_retained(size, overlap)
+    cols, rows = int(dims[0]), int(dims[1])
+    canvas = None
+
+    for i, tile in tile_iter:
+        if canvas is None:
+            out_dtype = dtype if dtype is not None else tile.dtype
+            # (rows*retained, cols*retained) matches np.concatenate cut geometry
+            canvas = np.empty((rows * retained, cols * retained), dtype=out_dtype)
+        c, r = grid_index(i, dims, acqui_ori)
+        paste_cut_tile(canvas, tile, c, r, retained, border)
+
+    if canvas is None:
+        raise ValueError("assemble_cut received no tiles")
+    return canvas
 
 
 def find_imaging_csv(img_path: pathlib.Path) -> pathlib.Path:
@@ -215,7 +308,7 @@ class Raster(ABC):
 
         return [ff_subtract(i, ff_image, ff_bval, ff_scale) for i in self._images]
 
-    def applyFF_BaSiC(self, plot: bool):
+    def applyFF_BaSiC(self, plot: bool, images: Optional[List[np.ndarray]] = None):
         """
         Applies flat-field correction to fetched images using BaSiC. This technique simulates a FF and
         dark image based on common shared features across the full raster (e.g. 64 images).
@@ -225,28 +318,21 @@ class Raster(ABC):
         Implemented in v2.1.0 by Peter Suzuki, Youngbin Lim
 
         Arguments:
-            None
+            plot (bool): Whether to show diagnostic plots.
+            images (list, optional): Explicit tile list; defaults to self._images.
 
         Returns:
-            None
-
+            list[np.ndarray]: Flat-field corrected tile images.
         """
-        # print("Running BaSiC for FF correction...")
-
-        # Load images
-        imgarray = []
-        for img in self._images:
-            # print(img.shape)
-            imgarray.append(img)
-        images = np.asarray(imgarray)
+        imgarray = list(images) if images is not None else list(self._images)
+        stacked = np.asarray(imgarray)
 
         # Initialize BaSiC and train
         basic = BaSiC(get_darkfield=False, smoothness_flatfield=1)
-        basic.fit(images)
+        basic.fit(stacked)
 
         # Smooth FF image and apply transform to each raw image
         ffImage = gaussian_filter(basic.flatfield, sigma=50)
-        # StitchingSettings.ffImages[self.params.channel] = ffImage # save ffImage to settings
 
         ffbval = 0
         ffscale = 1
@@ -370,11 +456,11 @@ class Raster(ABC):
             (np.ndarray) A stitched image array
 
         """
-
-        self.fetch_images()
         if method == "cut":
+            # cut_stitch streams tiles (or loads for BaSiC); do not prefetch all
             return self.cut_stitch(plot)
-        elif method == "smart":
+        self.fetch_images()
+        if method == "smart":
             return self.smart_stitch()
         elif method == "overlap":
             return self.overlap_stitch()
@@ -392,66 +478,46 @@ class Raster(ABC):
         """
         raise NotImplementedError("Functionality not ready yet.")
 
-    def cut_stitch(self, plot: bool):
+    def cut_stitch(self, plot: bool = False):
         """
         Stitches a raster via the 'cut' method. Trims borders according to image overlap and
-        concatenates along both axes. If RasterParameters.auto_ff is True, performs
-        flat-field correction prior to stitching.
+        pastes into a preallocated canvas. If RasterParameters.auto_ff is True, loads all
+        tiles for BaSiC flat-field correction, then pastes corrected tiles.
 
-        Arguments:
-            None
+        When auto_ff is False, tiles are streamed one at a time (read → rotate → trim → paste → drop).
 
         Returns:
             (np.ndarray) A stitched image array
-
         """
-        imsize = self.params.size
-        margin = int(imsize * self.params.overlap / 2)  # Edge dim to trim
-        retained = imsize - 2 * margin
+        params = self.params
+        # Validate overlap early
+        cut_margin_retained(params.size, params.overlap)
 
-        if self.params.overlap < 0 or self.params.overlap >= 1:
-            raise ValueError("Overlap must be ≥ 0 and < 1")
+        if params.auto_ff and params.ff_type == "BaSiC":
+            tiles = load_tiles(self._image_refs, params.rotation)
+            self._images = tiles
+            corrected = self.applyFF_BaSiC(plot, images=tiles)
+            self.ffCorrectedImages = corrected # TODO: figure out why images are being assigned to an attribute
+            result = assemble_cut(
+                enumerate(corrected),
+                dims=params.dims,
+                acqui_ori=params.acqui_ori,
+                overlap=params.overlap,
+                size=params.size,
+            )
+            self._images = None
+            self.ffCorrectedImages = None
+            return result
 
-        # Catch no overlap case
-        if margin == 0:
-            border = slice(0, None)
-        else:
-            border = slice(margin, -margin)
-
-        tiles = self._images
-        if self.params.auto_ff and self.params.ff_type == "BaSiC":
-            tiles = self.ffCorrectedImages = self.applyFF_BaSiC(plot)
-            # print("completed BaSiC FF correction")
-
-            # logging.info(
-            #     "BaSiC Flat-Field Corrected Image | Ch: {}, Exp: {}".format(
-            #         self.params.channel, self.params.exposure
-            #     )
-            # )
-
-        # elif self.params.auto_ff and self.params.ff_type == "BaSiC_masked":
-        #     tiles = self.ffCorrectedImages = self.applyFF_BaSiC_masked()
-        #     print("completed BaSiC FF correction with mask")
-
-        #     logging.info(
-        #         "BaSiC Flat-Field Corrected Image | Ch: {}, Exp: {}".format(
-        #             self.params.channel, self.params.exposure
-        #         )
-        #     )
-
-        trimmedTiles = [tile[border, border] for tile in tiles]  # Trim
-        tileArray = np.asarray(trimmedTiles)
-
-        arrangedTiles = np.reshape(
-            tileArray, (self.params.dims[0], self.params.dims[1], retained, retained)
+        result = assemble_cut(
+            iter_tiles(self._image_refs, params.rotation),
+            dims=params.dims,
+            acqui_ori=params.acqui_ori,
+            overlap=params.overlap,
+            size=params.size,
         )
-        if self.params.acqui_ori[0]:  # if origin on on right, flip horizontally (view returned)
-            arrangedTiles = np.flip(arrangedTiles, 0)
-        if self.params.acqui_ori[1]:  # If origin on bottom, flip vertically (view returned)
-            arrangedTiles = np.flip(arrangedTiles, 1)
-        rowsStitched = np.concatenate(arrangedTiles, axis=2)  # Stitch rows
-        fullStitched = np.concatenate(rowsStitched, axis=0)  # Stitch cols
-        return fullStitched
+        self._images = None
+        return result
 
     def detect_overlap(self) -> float:
         """
@@ -872,6 +938,7 @@ class Raster(ABC):
         return selfstem < otherstem
 
 
+# TODO: deprecate in future versions if unused
 class FlatRaster(Raster):
     """Raster subclass for handling flat unstacked single-file tile images.
 
@@ -885,29 +952,9 @@ class FlatRaster(Raster):
 
     def fetch_images(self):
         """
-        Fetches (loads into memory) and rotates images (if indicated by raster parameters)
+        Fetches (loads into memory) and rotates images (if indicated by raster parameters).
 
-        Arguments:
-            None
-
-        Returns:
-            None
-
+        Thin wrapper around load_tiles for callers that need random access (detection, rescue).
         """
-        # r = self._params.rotation
-        #
-        # images = [io.imread(img) for img in self.image_refs]
-        #
-        # if r:
-        #     images = [rotate_image(img, self._params.rotation) for img in images]
-        #
-        # self._images = images
-
-        self._images = [io.imread(img) for img in self._image_refs]
-
-        if self._params.rotation:
-            # if rotation value provided, rotate all images
-            self._images = [
-                rotate_image(img, self._params.rotation) for img in self._images
-            ]
+        self._images = load_tiles(self._image_refs, self._params.rotation)
 

--- a/test/test_background_subtract.py
+++ b/test/test_background_subtract.py
@@ -1,0 +1,118 @@
+"""Unit tests for background subtraction (serial and parallel)."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import numpy as np
+import pandas as pd
+import pytest
+from skimage import io
+
+from mercury.stitching import BackgroundSubtractor, backgroud_subtract, subtract_single_image
+
+
+SETTINGS = ["setup", "dname", "channel", "exposure"]
+
+
+def _write_tif(path: Path, arr: np.ndarray) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    io.imsave(path, arr, check_contrast=False)
+
+
+def _make_stitched_fixture(tmp_path: Path, include_bad: bool = False):
+    """Build a minimal stitched_images tree + CSV for BackgroundSubtractor."""
+    root = tmp_path / "exp"
+    stitched = root / "stitched_images"
+    stitched.mkdir(parents=True)
+
+    bg = (np.full((32, 32), 100, dtype=np.uint16))
+    t0 = (np.full((32, 32), 500, dtype=np.uint16))
+    t1 = (np.full((32, 32), 250, dtype=np.uint16))
+
+    bg_name = "background.tif"
+    t0_name = "target_0.tif"
+    t1_name = "target_1.tif"
+
+    _write_tif(stitched / bg_name, bg)
+    _write_tif(stitched / t0_name, t0)
+    _write_tif(stitched / t1_name, t1)
+
+    rows = [
+        {"image_path": bg_name, "setup": "s1", "dname": "d1", "channel": "cyan", "exposure": 100},
+        {"image_path": t0_name, "setup": "s1", "dname": "d1", "channel": "cyan", "exposure": 100},
+        {"image_path": t1_name, "setup": "s1", "dname": "d1", "channel": "cyan", "exposure": 100},
+    ]
+
+    if include_bad:
+        bad_name = "bad_target.tif"
+        (stitched / bad_name).write_bytes(b"not a tiff")
+        rows.append(
+            {"image_path": bad_name, "setup": "s1", "dname": "d1", "channel": "cyan", "exposure": 100}
+        )
+
+    pd.DataFrame(rows).to_csv(stitched / "stitched_images.csv", index=False)
+    return root, bg, t0, t1
+
+
+@pytest.mark.parametrize("n_workers", [1, 2])
+def test_subtract_serial_and_parallel(tmp_path, n_workers):
+    root, bg, t0, t1 = _make_stitched_fixture(tmp_path)
+    bg_path = root / "stitched_images" / "background.tif"
+
+    subtractor = BackgroundSubtractor(root)
+    subtractor.subtract(
+        background_images=[bg_path],
+        settings_to_match=SETTINGS,
+        n_workers=n_workers,
+    )
+
+    out_dir = root / "bgsub_images"
+    csv_path = out_dir / "bgsub_images.csv"
+    assert csv_path.exists()
+
+    out0 = io.imread(out_dir / "target_0.tif")
+    out1 = io.imread(out_dir / "target_1.tif")
+    np.testing.assert_array_equal(out0, backgroud_subtract(bg, t0))
+    np.testing.assert_array_equal(out1, backgroud_subtract(bg, t1))
+    assert out0.dtype == np.uint16
+    expected0 = np.clip(t0.astype(float) - bg.astype(float), 0, 65535).astype(np.uint16)
+    np.testing.assert_array_equal(out0, expected0)
+
+    df = pd.read_csv(csv_path)
+    assert set(df["image_path"]) == {"target_0.tif", "target_1.tif"}
+    assert df["success"].all()
+    assert (df["background_image"] == "background.tif").all()
+
+
+def test_subtract_marks_failure(tmp_path):
+    root, _, _, _ = _make_stitched_fixture(tmp_path, include_bad=True)
+    bg_path = root / "stitched_images" / "background.tif"
+
+    subtractor = BackgroundSubtractor(root)
+    subtractor.subtract(
+        background_images=[bg_path],
+        settings_to_match=SETTINGS,
+        n_workers=1,
+        verbose=False,
+    )
+
+    df = pd.read_csv(root / "bgsub_images" / "bgsub_images.csv")
+    bad_row = df[df["image_path"] == "bad_target.tif"].iloc[0]
+    assert bad_row["success"] == False
+    assert pd.isna(bad_row["background_image"])
+    assert not (root / "bgsub_images" / "bad_target.tif").exists()
+
+    ok = df[df["image_path"] != "bad_target.tif"]
+    assert ok["success"].all()
+
+
+def test_subtract_single_image_copy_when_no_background(tmp_path):
+    src = tmp_path / "src.tif"
+    dst = tmp_path / "dst.tif"
+    arr = np.arange(32 * 32, dtype=np.uint16).reshape(32, 32)
+    _write_tif(src, arr)
+
+    ok, err = subtract_single_image(None, str(src), str(dst))
+    assert ok and err is None
+    np.testing.assert_array_equal(io.imread(dst), arr)

--- a/test/test_stitching_cut.py
+++ b/test/test_stitching_cut.py
@@ -1,0 +1,142 @@
+"""Unit tests for cut-stitch paste geometry and streaming behavior."""
+
+from __future__ import annotations
+
+from concurrent.futures import ProcessPoolExecutor
+from pathlib import Path
+
+import numpy as np
+import pytest
+from skimage import io
+
+from mercury.stitching import stitch_single_raster
+from mercury.stitching import rastering
+
+
+def _concat_cut_reference(tiles, dims, acqui_ori, overlap, size):
+    """Historical trim → reshape → flip → concatenate geometry."""
+    margin = int(size * overlap / 2)
+    retained = size - 2 * margin
+    if margin == 0:
+        border = slice(0, None)
+    else:
+        border = slice(margin, -margin)
+
+    trimmed = [tile[border, border] for tile in tiles]
+    tile_array = np.asarray(trimmed)
+    arranged = np.reshape(tile_array, (dims[0], dims[1], retained, retained))
+    if acqui_ori[0]:
+        arranged = np.flip(arranged, 0)
+    if acqui_ori[1]:
+        arranged = np.flip(arranged, 1)
+    rows = np.concatenate(arranged, axis=2)
+    return np.concatenate(rows, axis=0)
+
+
+def _make_synthetic_tiles(cols, rows, size, seed=0):
+    rng = np.random.default_rng(seed)
+    tiles = []
+    for c in range(cols):
+        for r in range(rows):
+            # Unique base level per tile + mild gradient for seam checks
+            base = ((c * rows + r + 1) * 1000) % 50000
+            yy, xx = np.mgrid[0:size, 0:size]
+            tile = (base + (yy // 8) + (xx // 16)).astype(np.uint16)
+            # sprinkle noise so rotations aren't perfectly uniform
+            tile = tile + rng.integers(0, 5, size=tile.shape, dtype=np.uint16)
+            tiles.append(tile)
+    return tiles
+
+
+@pytest.mark.parametrize(
+    "acqui_ori",
+    [(False, False), (True, False), (False, True), (True, True)],
+)
+@pytest.mark.parametrize("rotation", [0.0, 1.5])
+def test_assemble_cut_matches_concat_reference(acqui_ori, rotation, tmp_path):
+    cols, rows, size, overlap = 3, 2, 64, 0.1
+    tiles = _make_synthetic_tiles(cols, rows, size)
+
+    refs = []
+    for i, tile in enumerate(tiles):
+        path = tmp_path / f"tile_{i:02d}.tif"
+        io.imsave(path, tile, check_contrast=False)
+        refs.append(path)
+
+    # Reference uses the same rotate_image path as production loaders
+    rotated = rastering.load_tiles(refs, rotation=rotation)
+    expected = _concat_cut_reference(rotated, (cols, rows), acqui_ori, overlap, size)
+
+    got = rastering.assemble_cut(
+        rastering.iter_tiles(refs, rotation=rotation),
+        dims=(cols, rows),
+        acqui_ori=acqui_ori,
+        overlap=overlap,
+        size=size,
+    )
+    np.testing.assert_array_equal(got, expected)
+
+
+def test_cut_stitch_streaming_clears_images(tmp_path):
+    cols, rows, size, overlap = 2, 2, 32, 0.0
+    tiles = _make_synthetic_tiles(cols, rows, size)
+    refs = []
+    for i, tile in enumerate(tiles):
+        path = tmp_path / f"tile_{i:02d}.tif"
+        io.imsave(path, tile, check_contrast=False)
+        refs.append(path)
+
+    params = rastering.RasterParams(
+        overlap=overlap,
+        size=size,
+        acqui_ori=(False, False),
+        rotation=0.0,
+        dims=(cols, rows),
+        auto_ff=False,
+    )
+    raster = rastering.FlatRaster(image_refs=refs, params=params)
+    out = raster.stitch(method="cut")
+    assert out.shape == (rows * size, cols * size)
+    assert raster._images is None
+
+
+def test_parallel_stitch_single_raster_smoke(tmp_path):
+    cols, rows, size, overlap = 2, 2, 32, 0.0
+
+    def _write_raster(subdir: Path):
+        tiles = _make_synthetic_tiles(cols, rows, size, seed=hash(subdir.name) % 10_000)
+        refs = []
+        for i, tile in enumerate(tiles):
+            path = subdir / f"tile_{i:02d}.tif"
+            io.imsave(path, tile, check_contrast=False)
+            refs.append(str(path))
+        return refs
+
+    jobs = []
+    for name in ("a", "b"):
+        d = tmp_path / name
+        d.mkdir()
+        refs = _write_raster(d)
+        params = rastering.RasterParams(
+            overlap=overlap,
+            size=size,
+            acqui_ori=(True, False),
+            rotation=0.0,
+            dims=(cols, rows),
+            auto_ff=False,
+        )
+        out = tmp_path / f"{name}_stitched.tif"
+        jobs.append((refs, params, out))
+
+    with ProcessPoolExecutor(max_workers=2) as ex:
+        futs = [
+            ex.submit(stitch_single_raster, refs, params, out, "cut")
+            for refs, params, out in jobs
+        ]
+        results = [f.result() for f in futs]
+
+    for ok, path, err in results:
+        assert ok, err
+        assert Path(path).exists()
+        img = io.imread(path)
+        assert img.shape == (rows * size, cols * size)

--- a/test/test_stitching_cut.py
+++ b/test/test_stitching_cut.py
@@ -77,6 +77,17 @@ def test_assemble_cut_matches_concat_reference(acqui_ori, rotation, tmp_path):
     np.testing.assert_array_equal(got, expected)
 
 
+def test_rotate_image_preserves_shape_and_dtype():
+    rng = np.random.default_rng(0)
+    img = rng.integers(0, 40000, size=(64, 64), dtype=np.uint16)
+    out = rastering.rotate_image(img, 1.5)
+    assert out.shape == img.shape
+    assert out.dtype == np.uint16
+    # Identity angle should not allocate a distinct buffer copy of values
+    same = rastering.rotate_image(img, 0.0)
+    np.testing.assert_array_equal(same, img)
+
+
 def test_cut_stitch_streaming_clears_images(tmp_path):
     cols, rows, size, overlap = 2, 2, 32, 0.0
     tiles = _make_synthetic_tiles(cols, rows, size)

--- a/test/test_stitching_perf.py
+++ b/test/test_stitching_perf.py
@@ -1,6 +1,11 @@
 """Lightweight single-raster stitching performance harness (wall time + peak RSS).
 
 Not run in default CI; mark as slow and skip if bench data is absent.
+
+Baselines (print lines for PR notes; no absolute thresholds):
+1. Pre streaming/parallel plan — ``rotation=0`` on main before paste/stream.
+2. Post streaming/parallel plan — same harness after paste/stream/pool.
+3. Post cv2.warpAffine rotation — ``test_single_raster_stitch_perf_rotated``.
 """
 
 from __future__ import annotations
@@ -21,6 +26,8 @@ DEFAULT_RASTER_REL = Path(
     "raw_images/2026-07-30_10-54-29_d1_aura_cyan_2_10_dynamic_range_2x2_1_test"
 )
 TILE_SIZE = 1600
+# Representative fixed angle (same order as production e2e); keeps detection out of the timed path.
+BENCH_ROTATION_DEG = 1.24
 
 
 def _bench_root() -> Path:
@@ -45,8 +52,7 @@ def _peak_rss_kb() -> tuple[int | None, int]:
     return vmhwm, ru_maxrss
 
 
-@pytest.mark.slow
-def test_single_raster_stitch_perf(tmp_path):
+def _load_bench_raster():
     root = _bench_root()
     raster_dir = root / DEFAULT_RASTER_REL
     imaging_csv = root / "imaging.csv"
@@ -67,18 +73,23 @@ def test_single_raster_stitch_perf(tmp_path):
     width = int(group["raster_width"].iloc[0])
     height = int(group["raster_height"].iloc[0])
     refs = [(root / p).resolve() for p in group["image_path"].tolist()]
+    return refs, overlap, width, height
+
+
+def _run_single_raster_bench(tmp_path, rotation: float, label: str):
+    refs, overlap, width, height = _load_bench_raster()
 
     params = rastering.RasterParams(
         overlap=overlap,
         size=TILE_SIZE,
         acqui_ori=(True, False),
-        rotation=0.0,
+        rotation=rotation,
         dims=(width, height),
         auto_ff=False,
         ff_type="BaSiC",
     )
 
-    outpath = tmp_path / "bench_stitched.tif"
+    outpath = tmp_path / f"bench_stitched_{label}.tif"
     margin = int(TILE_SIZE * overlap / 2)
     retained = TILE_SIZE - 2 * margin
     # Historical cut geometry: (rows * retained, cols * retained)
@@ -90,7 +101,8 @@ def test_single_raster_stitch_perf(tmp_path):
     vmhwm_kb, ru_maxrss_kb = _peak_rss_kb()
 
     print(
-        f"stitch_perf raster={DEFAULT_RASTER_REL.name} "
+        f"stitch_perf label={label} rotation={rotation} "
+        f"raster={DEFAULT_RASTER_REL.name} "
         f"wall_s={elapsed:.3f} "
         f"VmHWM_kB={vmhwm_kb} "
         f"ru_maxrss_kB={ru_maxrss_kb}"
@@ -100,3 +112,15 @@ def test_single_raster_stitch_perf(tmp_path):
     assert path.exists()
     stitched = io.imread(path)
     assert stitched.shape == expected_shape
+
+
+@pytest.mark.slow
+def test_single_raster_stitch_perf(tmp_path):
+    """Baselines 1–2: rotation=0 before/after streaming+parallel plan."""
+    _run_single_raster_bench(tmp_path, rotation=0.0, label="rotation0")
+
+
+@pytest.mark.slow
+def test_single_raster_stitch_perf_rotated(tmp_path):
+    """Baseline 3: non-zero rotation after switching rotate_image to cv2.warpAffine."""
+    _run_single_raster_bench(tmp_path, rotation=BENCH_ROTATION_DEG, label="cv2_rotation")

--- a/test/test_stitching_perf.py
+++ b/test/test_stitching_perf.py
@@ -1,0 +1,102 @@
+"""Lightweight single-raster stitching performance harness (wall time + peak RSS).
+
+Not run in default CI; mark as slow and skip if bench data is absent.
+"""
+
+from __future__ import annotations
+
+import os
+import resource
+import time
+from pathlib import Path
+
+import pytest
+from skimage import io
+
+from mercury.stitching import stitch_single_raster
+from mercury.stitching import rastering
+
+DEFAULT_BENCH_ROOT = Path("/home/jzhang/Documents/scope_data/20260730")
+DEFAULT_RASTER_REL = Path(
+    "raw_images/2026-07-30_10-54-29_d1_aura_cyan_2_10_dynamic_range_2x2_1_test"
+)
+TILE_SIZE = 1600
+
+
+def _bench_root() -> Path:
+    return Path(os.environ.get("MERCURY_STITCH_BENCH_DIR", DEFAULT_BENCH_ROOT))
+
+
+def _read_vmhwm_kb() -> int | None:
+    """Peak RSS (VmHWM) in kB from /proc/self/status, or None if unavailable."""
+    status_path = Path("/proc/self/status")
+    if not status_path.exists():
+        return None
+    for line in status_path.read_text().splitlines():
+        if line.startswith("VmHWM:"):
+            return int(line.split()[1])
+    return None
+
+
+def _peak_rss_kb() -> tuple[int | None, int]:
+    vmhwm = _read_vmhwm_kb()
+    # Linux: ru_maxrss is already in kilobytes
+    ru_maxrss = int(resource.getrusage(resource.RUSAGE_SELF).ru_maxrss)
+    return vmhwm, ru_maxrss
+
+
+@pytest.mark.slow
+def test_single_raster_stitch_perf(tmp_path):
+    root = _bench_root()
+    raster_dir = root / DEFAULT_RASTER_REL
+    imaging_csv = root / "imaging.csv"
+
+    if not imaging_csv.exists() or not raster_dir.is_dir():
+        pytest.skip(f"Stitch bench data not found at {root} / {DEFAULT_RASTER_REL}")
+
+    import pandas as pd
+
+    df = pd.read_csv(imaging_csv)
+    parent_key = str(DEFAULT_RASTER_REL).replace("\\", "/")
+    mask = df["image_path_parent"].astype(str).str.replace("\\", "/") == parent_key
+    group = df.loc[mask].sort_values(by=["raster_col_index", "raster_row_index"])
+    if group.empty:
+        pytest.skip(f"No imaging.csv rows for {parent_key}")
+
+    overlap = float(group["raster_overlap"].iloc[0])
+    width = int(group["raster_width"].iloc[0])
+    height = int(group["raster_height"].iloc[0])
+    refs = [(root / p).resolve() for p in group["image_path"].tolist()]
+
+    params = rastering.RasterParams(
+        overlap=overlap,
+        size=TILE_SIZE,
+        acqui_ori=(True, False),
+        rotation=0.0,
+        dims=(width, height),
+        auto_ff=False,
+        ff_type="BaSiC",
+    )
+
+    outpath = tmp_path / "bench_stitched.tif"
+    margin = int(TILE_SIZE * overlap / 2)
+    retained = TILE_SIZE - 2 * margin
+    # Historical cut geometry: (rows * retained, cols * retained)
+    expected_shape = (height * retained, width * retained)
+
+    t0 = time.perf_counter()
+    ok, path, err = stitch_single_raster(refs, params, outpath, method="cut")
+    elapsed = time.perf_counter() - t0
+    vmhwm_kb, ru_maxrss_kb = _peak_rss_kb()
+
+    print(
+        f"stitch_perf raster={DEFAULT_RASTER_REL.name} "
+        f"wall_s={elapsed:.3f} "
+        f"VmHWM_kB={vmhwm_kb} "
+        f"ru_maxrss_kB={ru_maxrss_kb}"
+    )
+
+    assert ok, err
+    assert path.exists()
+    stitched = io.imread(path)
+    assert stitched.shape == expected_shape


### PR DESCRIPTION
Refactor of stitching module for the sake of memory efficiency and throughput. Implemented the following changes:

1. Lazy loading of images within a raster by default (as opposed to eager loading all into memory). Peak memory consumption now the size of the stitched image plus a single tile. Note that flat-field correction still requires eager loading. 
2. Parallel raster stitching.
3. Usage of faster cv2.warpAffine instead of skimage for rotation.
4. Parallel background subtraction. Individual background images are now cached. No longer need to read the background image each time a subtraction is applied.

Explicitly tested performance (speed/memory) and output pre/post. ~25% reduction in memory usage, ~80% reduction in time to stitch one raster. Output is identical (see plot below). 

<img width="1800" height="750" alt="baseline1_vs_baseline3_rot0 98" src="https://github.com/user-attachments/assets/508a4178-4d4e-4d5d-bd10-6fe2573dc401" />

