### PR TITLE
feat/parallel-feature-finding

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,4 +57,24 @@ Done:
 
 Down the line:
 1. Default source of truth for overlap parameter should come from `imaging.csv`, not auto-calculated. Additionally, overlap should really be considered as a per-image parameter (or at least a shared parameter across images taken with the same settings).
-2. Prefetch + aggressive release + memmap/tiled writes
+2. Prefetch + aggressive release + memmap/tiled writes.
+
+### Processing
+
+#### Current Implementation
+- Stamp: a cropped pixel tile, not a mask. The class implemented in the processing module contains the tile data, the slice (the row and column slice that produced the tile in chip coordinates), the index (grid position on the device), and the identifier.
+- Feature finding code identifies buttons and/or chambers within stamps. 
+
+1. Parallelize across stamps for chamber/button finding.
+
+2. Vectorize stamp mapping across a batch dimension. Consider the following approach:
+    - After `set_reference`, pre-build boolean masks for the chamber, button, and annulus  ([N, H, W]).
+    - Load target image via memmap, get stamps [N, H, W], vectorized reductions via the masks, then calculate per-stamp median, sum, and std
+        - sum/std can be vectorized, stick to loop for median
+    - Free aggressively. Do not keep the full chip image after the row is appended to the `csv`. Don't keep the full stitch once stamps are cropped (or never materialized and use memmap + slice). Delete stamps to free up memory, if needed.
+    - Can parallelize the above process across chip images. 
+
+3. Optimize button finding.
+    - Remove unused copy of cicularSubsection; cut deepcopy in button search.
+    - Vectorize the course grid search
+    - Update 110 to the actual shape (100)

--- a/README.md
+++ b/README.md
@@ -67,14 +67,32 @@ Down the line:
 
 1. Parallelize across stamps for chamber/button finding.
 
-2. Vectorize stamp mapping across a batch dimension. Consider the following approach:
-    - After `set_reference`, pre-build boolean masks for the chamber, button, and annulus  ([N, H, W]).
-    - Load target image via memmap, get stamps [N, H, W], vectorized reductions via the masks, then calculate per-stamp median, sum, and std
-        - sum/std can be vectorized, stick to loop for median
-    - Free aggressively. Do not keep the full chip image after the row is appended to the `csv`. Don't keep the full stitch once stamps are cropped (or never materialized and use memmap + slice). Delete stamps to free up memory, if needed.
-    - Can parallelize the above process across chip images. 
+2. RoiSet-based mapping (replace mapto hot path)
+   - After feature finding / set_reference, build RoiSet:
+       slices, indices, ids,
+       chamber/button geometry + blank flags,
+       boolean masks [N,H,W] (True = inside ROI, same convention as circularSubsection today)
+   - quantify(path|memmap, roi) -> DataFrame
+       extract stamps [N,H,W];
+       vectorized sum/mean/std; median in a loop over N;
+       emit same columns as Chamber/Button.summarize (incl. BG-sub, annulus)
+       for failures, NaN rows (same as BlankChamber / BlankButton)
+   - render_summary(stamps, roi, metrics=None) -> image
+       annotate from geometry (+ optional metric text); stitch; no Chamber/Button
+       enable annotation of both chamber / button features if 'all' is passed
+   - Processor._process_from_reference:
+       single crop → quantify → (if save_summary_images) render → free stamps
+       do not keep full ChipImage / mapto on this path
+   - Keep ChipImage.mapto / summary_image for now; deprecate later
+   - v1: serial over images; image-level pool as follow-up
+   - Test: legacy mapto+summarize vs quantify; unity scatter (reuse processing_compare)
+   - Prefer `processing/roi.py` to prevent bloating of `chip.py`.
+   - Down the line: ensure that RoiSet to quantify to render summary is the standard. No need to do this immediately.
 
 3. Optimize button finding.
     - Remove unused copy of cicularSubsection; cut deepcopy in button search.
     - Vectorize the course grid search
     - Update 110 to the actual shape (100)
+
+4. Abstract `roi.py`
+    - Abstract classes. For each geometry, specify headers and metric calculation functions

--- a/src/mercury/processing/__init__.py
+++ b/src/mercury/processing/__init__.py
@@ -2,11 +2,13 @@
 
 """Top-level package for processing."""
 
-from mercury.processing import chip, experiment
+from mercury.processing import chip, experiment, roi
 
 __author__ = """Daniel Mokhtari"""
 __email__ = ""
 __version__ = "0.1.0"
+
+import warnings
 
 import skimage
 import pandas as pd
@@ -28,15 +30,15 @@ class Processor:
         assert self.features in ('button', 'chamber', 'all'), "features argument must be 'button', 'chamber', or 'all'."
 
         self.reference_images = {dname: None for dname in self.experiment.devices}
+        self.reference_rois = {dname: None for dname in self.experiment.devices}
 
         self.summary_image_dir = self.experiment.root / 'summary_images'
 
-        # print('Loaded the following images:')
-        # for image in image_data['image_path']:
-        #     print(image)
-
     def _update_reference_image(self, dname: str, chip_image: chip.ChipImage):
         self.reference_images[dname] = chip_image
+
+    def _update_reference_roi(self, dname: str, chip_image: chip.ChipImage):
+        self.reference_rois[dname] = roi.RoiSet.from_chip(chip_image, self.features)
 
     def _process_features(
         self,
@@ -53,6 +55,27 @@ class Processor:
             chip_image.findChambers(coerce_center=coerce_chamber_center, n_jobs=n_jobs)
             chip_image.findButtons(n_jobs=n_jobs)
 
+    def _summary_outpath(self, image: Union[Path, str]) -> Path:
+        image = Path(image) if not isinstance(image, Path) else image
+        outpath = self.summary_image_dir / image.relative_to(self.experiment.root)
+        outpath.parent.mkdir(parents=True, exist_ok=True)
+        return outpath
+
+    def _imsave_summary(
+        self,
+        summary_image,
+        outpath: Path,
+        *,
+        as_ubyte: bool = False,
+        compress: bool = False,
+    ):
+        if as_ubyte:
+            summary_image = skimage.img_as_ubyte(summary_image)
+        save_kwargs = {'check_contrast': False}
+        if compress and outpath.suffix.lower() in {'.tif', '.tiff'}:
+            save_kwargs['compression'] = 'zlib'
+        skimage.io.imsave(outpath, summary_image, **save_kwargs)
+
     def _save_summary_image(
         self,
         chip_image: chip.ChipImage,
@@ -60,28 +83,38 @@ class Processor:
         *,
         as_ubyte: bool = False,
         compress: bool = False,
+        roi_set: roi.RoiSet = None,
+        stamps=None,
+        metrics: pd.DataFrame = None,
     ):
         """Save annotated summary image for debugging/review.
 
-        Args:
-            chip_image: Processed chip image to summarize.
-            image: Source image path (used to mirror relative layout under summary_image_dir).
-            as_ubyte: If True, convert to uint8 before saving.
-            compress: If True and the output is TIFF, write with zlib compression.
+        Prefers RoiSet + render_summary when ``roi_set`` (and stamps) are provided.
         """
-        image = Path(image) if not isinstance(image, Path) else image
-        outpath = self.summary_image_dir / image.relative_to(self.experiment.root)
-        outpath.parent.mkdir(parents=True, exist_ok=True)
+        outpath = self._summary_outpath(image)
 
-        summary_image = chip_image.summary_image(stamptype=self.features)
-        if as_ubyte:
-            summary_image = skimage.img_as_ubyte(summary_image)
+        if roi_set is not None:
+            if stamps is None:
+                stamps = roi.stamps_from_chip(chip_image)
+            summary_image = roi.render_summary(
+                stamps, roi_set, features=self.features, metrics=metrics
+            )
+        else:
+            warnings.warn(
+                "Saving summary via ChipImage.summary_image is deprecated; "
+                "prefer RoiSet + render_summary.",
+                DeprecationWarning,
+                stacklevel=2,
+            )
+            if self.features == 'all':
+                # Legacy summary_image does not support 'all'; render chamber overlay only
+                summary_image = chip_image.summary_image(stamptype='chamber')
+            else:
+                summary_image = chip_image.summary_image(stamptype=self.features)
 
-        save_kwargs = {'check_contrast': False}
-        if compress and outpath.suffix.lower() in {'.tif', '.tiff'}:
-            save_kwargs['compression'] = 'zlib'
-
-        skimage.io.imsave(outpath, summary_image, **save_kwargs)
+        self._imsave_summary(
+            summary_image, outpath, as_ubyte=as_ubyte, compress=compress
+        )
 
     def set_corners(self, dname: str, corners: List[Tuple]):
         assert dname in self.experiment.devices, '{} not found in experiment.'.format(dname)
@@ -108,7 +141,6 @@ class Processor:
     ):
         """Set reference image for a device."""
 
-
         image = Path(image) if not isinstance(image, Path) else image
 
         # Get device number and corners via metadata lookup 
@@ -128,10 +160,20 @@ class Processor:
         self._process_features(chip_image, coerce_chamber_center, n_jobs=n_jobs)
         
         self._update_reference_image(dname, chip_image)
+        self._update_reference_roi(dname, chip_image)
 
         if save_summary_images:
+            roi_set = self.reference_rois[dname]
+            stamps = roi.stamps_from_chip(chip_image)
+            metrics = roi.quantify(stamps, roi_set, features=self.features)
             self._save_summary_image(
-                chip_image, image, as_ubyte=as_ubyte, compress=compress
+                chip_image,
+                image,
+                as_ubyte=as_ubyte,
+                compress=compress,
+                roi_set=roi_set,
+                stamps=stamps,
+                metrics=metrics,
             )
 
     def process(
@@ -179,7 +221,7 @@ class Processor:
         compress: bool = False,
         n_jobs: int = -1,
     ):
-        """Process images with manually provided corners."""
+        """Process images with manually provided corners (find per image, RoiSet quantify)."""
         data = []
         for i in tqdm(range(len(self.image_data)), desc='Processing images', leave=False):
 
@@ -188,15 +230,25 @@ class Processor:
             chip_image.stamp()
             self._process_features(chip_image, coerce_chamber_center, n_jobs=n_jobs)
 
-            processed_data = chip_image.summarize().reset_index()
+            roi_set = roi.RoiSet.from_chip(chip_image, self.features)
+            stamps = roi.stamps_from_chip(chip_image)
+            processed = roi.quantify(stamps, roi_set, features=self.features)
+            processed_data = processed.reset_index()
             metadata = pd.DataFrame([self.image_data.iloc[i]] * len(processed_data)).reset_index(drop=True)
             merged = pd.concat([metadata, processed_data], axis=1)
             data.append(merged)
             
             if save_summary_images:
                 self._save_summary_image(
-                    chip_image, image, as_ubyte=as_ubyte, compress=compress
+                    chip_image,
+                    image,
+                    as_ubyte=as_ubyte,
+                    compress=compress,
+                    roi_set=roi_set,
+                    stamps=stamps,
+                    metrics=processed,
                 )
+            del stamps
         
         return pd.concat(data, ignore_index=False)
 
@@ -207,33 +259,97 @@ class Processor:
         compress: bool = False,
         n_jobs: int = -1,
     ):
-        """Process images by mapping from reference images.
+        """Process images by mapping RoiSet geometry from reference images.
 
-        n_jobs is accepted for API symmetry with process()/manual finding but unused here
-        (features are mapped, not re-detected).
+        When n_jobs > 1 and save_summary_images is False, quantifies images in a
+        process pool. Summary rendering stays serial (needs stamp tensors).
         """
+
+        # Fast parallel path when not saving summaries
+        if (
+            not save_summary_images
+            and roi._resolve_n_jobs(n_jobs) > 1
+            and len(self.image_data) > 1
+        ):
+            return self._process_from_reference_parallel(
+                as_ubyte=as_ubyte,
+                compress=compress,
+                n_jobs=n_jobs,
+            )
 
         data = []
         for i in tqdm(range(len(self.image_data)), desc='Processing images', leave=False):
 
             dname, image = self.image_data[['dname', 'image_path']].iloc[i]
 
-            reference = self.reference_images.get(dname)
-            if reference is None:
-                raise ValueError(f"No reference image set for device {dname}. Call set_reference() first.")
-            
-            chip_image = chip.ChipImage(self.experiment.devices[dname], image, reference.corners)
-            chip_image.stamp()
-            reference.mapto(chip_image, features=self.features)
-            
-            processed_data = chip_image.summarize().reset_index()
+            roi_set = self.reference_rois.get(dname)
+            if roi_set is None:
+                raise ValueError(
+                    f"No reference RoiSet for device {dname}. Call set_reference() first."
+                )
+
+            stamps = roi.extract_stamps(image, roi_set)
+            processed = roi.quantify(stamps, roi_set, features=self.features)
+            processed_data = processed.reset_index()
             metadata = pd.DataFrame([self.image_data.iloc[i]] * len(processed_data)).reset_index(drop=True)
             merged = pd.concat([metadata, processed_data], axis=1)
             data.append(merged)
             
             if save_summary_images:
-                self._save_summary_image(
-                    chip_image, image, as_ubyte=as_ubyte, compress=compress
+                # Single-crop: reuse stamps for render (no ChipImage/mapto)
+                outpath = self._summary_outpath(image)
+                summary_image = roi.render_summary(
+                    stamps, roi_set, features=self.features, metrics=processed
+                )
+                self._imsave_summary(
+                    summary_image, outpath, as_ubyte=as_ubyte, compress=compress
                 )
 
+            del stamps
+
+        return pd.concat(data, ignore_index=False)
+
+    def _process_from_reference_parallel(
+        self,
+        as_ubyte: bool = False,
+        compress: bool = False,
+        n_jobs: int = -1,
+    ):
+        """Parallel quantify across images (no summary images)."""
+        # Group by device so each job gets the right RoiSet
+        rows = []
+        paths = []
+        rois = []
+        features_list = []
+        for i in range(len(self.image_data)):
+            dname, image = self.image_data[['dname', 'image_path']].iloc[i]
+            roi_set = self.reference_rois.get(dname)
+            if roi_set is None:
+                raise ValueError(
+                    f"No reference RoiSet for device {dname}. Call set_reference() first."
+                )
+            rows.append(i)
+            paths.append(image)
+            rois.append(roi_set)
+            features_list.append(self.features)
+
+        # If all same device, one RoiSet; else per-path (worker gets its roi)
+        workers = roi._resolve_n_jobs(n_jobs)
+        payloads = list(zip(paths, rois, features_list))
+        chunksize = max(1, len(payloads) // (workers * 4))
+        with roi._stamp_process_pool(workers) as executor:
+            dfs = list(
+                tqdm(
+                    executor.map(roi._quantify_image_worker, payloads, chunksize=chunksize),
+                    total=len(payloads),
+                    desc='Processing images',
+                    leave=False,
+                )
+            )
+
+        data = []
+        for i, processed in zip(rows, dfs):
+            processed_data = processed.reset_index()
+            metadata = pd.DataFrame([self.image_data.iloc[i]] * len(processed_data)).reset_index(drop=True)
+            data.append(pd.concat([metadata, processed_data], axis=1))
         return pd.concat(data, ignore_index=False)

--- a/src/mercury/processing/__init__.py
+++ b/src/mercury/processing/__init__.py
@@ -38,15 +38,20 @@ class Processor:
     def _update_reference_image(self, dname: str, chip_image: chip.ChipImage):
         self.reference_images[dname] = chip_image
 
-    def _process_features(self, chip_image: chip.ChipImage, coerce_chamber_center: bool = False):
+    def _process_features(
+        self,
+        chip_image: chip.ChipImage,
+        coerce_chamber_center: bool = False,
+        n_jobs: int = -1,
+    ):
         """Extract feature processing logic into a reusable method."""
         if self.features == 'chamber':
-            chip_image.findChambers(coerce_center=coerce_chamber_center)
+            chip_image.findChambers(coerce_center=coerce_chamber_center, n_jobs=n_jobs)
         elif self.features == 'button':
-            chip_image.findButtons()
+            chip_image.findButtons(n_jobs=n_jobs)
         elif self.features == 'all':
-            chip_image.findChambers(coerce_center=coerce_chamber_center)
-            chip_image.findButtons()
+            chip_image.findChambers(coerce_center=coerce_chamber_center, n_jobs=n_jobs)
+            chip_image.findButtons(n_jobs=n_jobs)
 
     def _save_summary_image(
         self,
@@ -99,6 +104,7 @@ class Processor:
         coerce_chamber_center: bool = False,
         as_ubyte: bool = False,
         compress: bool = False,
+        n_jobs: int = -1,
     ):
         """Set reference image for a device."""
 
@@ -119,7 +125,7 @@ class Processor:
         # Create and process chip image
         chip_image = chip.ChipImage(self.experiment.devices[dname], image, corners)
         chip_image.stamp()
-        self._process_features(chip_image, coerce_chamber_center)
+        self._process_features(chip_image, coerce_chamber_center, n_jobs=n_jobs)
         
         self._update_reference_image(dname, chip_image)
 
@@ -136,6 +142,7 @@ class Processor:
         coerce_chamber_center: bool = False,
         as_ubyte: bool = False,
         compress: bool = False,
+        n_jobs: int = -1,
         **kwargs
     ):
         """High-level dispatcher that handles the mutual exclusivity logic."""
@@ -145,6 +152,7 @@ class Processor:
                 save_summary_images=save_summary_images,
                 as_ubyte=as_ubyte,
                 compress=compress,
+                n_jobs=n_jobs,
                 **kwargs,
             )
         
@@ -159,6 +167,7 @@ class Processor:
                 save_summary_images=save_summary_images,
                 as_ubyte=as_ubyte,
                 compress=compress,
+                n_jobs=n_jobs,
                 **kwargs,
             )
         
@@ -168,6 +177,7 @@ class Processor:
         coerce_chamber_center: bool = False,
         as_ubyte: bool = False,
         compress: bool = False,
+        n_jobs: int = -1,
     ):
         """Process images with manually provided corners."""
         data = []
@@ -176,7 +186,7 @@ class Processor:
             dname, image, c = self.image_data[['dname', 'image_path', 'corners']].iloc[i]
             chip_image = chip.ChipImage(self.experiment.devices[dname], image, c)
             chip_image.stamp()
-            self._process_features(chip_image, coerce_chamber_center)
+            self._process_features(chip_image, coerce_chamber_center, n_jobs=n_jobs)
 
             processed_data = chip_image.summarize().reset_index()
             metadata = pd.DataFrame([self.image_data.iloc[i]] * len(processed_data)).reset_index(drop=True)
@@ -195,8 +205,13 @@ class Processor:
         save_summary_images: bool = True,
         as_ubyte: bool = False,
         compress: bool = False,
+        n_jobs: int = -1,
     ):
-        """Process images by mapping from reference images."""
+        """Process images by mapping from reference images.
+
+        n_jobs is accepted for API symmetry with process()/manual finding but unused here
+        (features are mapped, not re-detected).
+        """
 
         data = []
         for i in tqdm(range(len(self.image_data)), desc='Processing images', leave=False):

--- a/src/mercury/processing/chip.py
+++ b/src/mercury/processing/chip.py
@@ -535,6 +535,7 @@ class Stamp:
 
         """
 
+        # TODO: imageCopy is unecessary- drop it
         imageCopy = img.copy()
         mask = np.zeros(imageCopy.shape)
         cv2.circle(mask, center, radius, 1, -1)  # Warning: MODIFIES mask IN PLACE!!
@@ -674,6 +675,7 @@ class Stamp:
         ######## DEFAULTS ########
         searchSpacing = 7
         radius = 15  # was 2x2 = 15, 4x4 = 7
+        # TODO: align tile width and height with stampWidth
         tileWidth = 110
         tileHeight = 110
         refiningRange = 7
@@ -691,6 +693,7 @@ class Stamp:
 
         boundingInset = int(tileWidth * boundingInsetRatio)
 
+        # TODO: for crude initial fit, precompute one template
         # Crude initial fit of center position (sparse initial serach grid, entire image stamp) by maximizing summed intensity
         for xIndex in range(boundingInset, tileWidth - boundingInset, searchSpacing):
             for yIndex in range(
@@ -701,6 +704,7 @@ class Stamp:
                 )
                 summedI = np.nansum(features["intensities"])
                 if summedI > maxI:
+                    # TODO: deepcopy also unnecessary here
                     maxI = deepcopy(summedI)
                     bestSpotParams = deepcopy(features)
 

--- a/src/mercury/processing/chip.py
+++ b/src/mercury/processing/chip.py
@@ -1,7 +1,10 @@
 import gc
+import os
 import warnings
 from copy import deepcopy
 from collections import namedtuple
+from concurrent.futures import ProcessPoolExecutor
+import multiprocessing as mp
 # from mercury.processing import experiment
 
 import numpy as np
@@ -10,10 +13,61 @@ from tqdm.auto import tqdm
 import pandas as pd
 
 from typing import List
-import multiprocessing
 
 import cv2
 import skimage
+
+
+_CV2_THREADS_LIMITED = False
+
+
+def _resolve_n_jobs(n_jobs: int) -> int:
+    """Resolve n_jobs: -1 means all CPUs; result is always >= 1."""
+    if n_jobs is None or n_jobs == -1:
+        return os.cpu_count() or 1
+    return max(1, int(n_jobs))
+
+
+def _ensure_cv2_single_threaded():
+    """Limit OpenCV threading once per process to avoid pool oversubscription."""
+    global _CV2_THREADS_LIMITED
+    if not _CV2_THREADS_LIMITED:
+        cv2.setNumThreads(1)
+        _CV2_THREADS_LIMITED = True
+
+
+def _chamber_worker(payload):
+    """Picklable worker: find chamber geometry for one stamp array."""
+    i, data, coerce_center = payload
+    _ensure_cv2_single_threaded()
+    stamp = Stamp(data, None, None, (0, 0), None)
+    stamp.findChamber(coerce_center=coerce_center)
+    if stamp.chamber is None or stamp.chamber.blankFlag:
+        return i, None
+    return i, (stamp.chamber.center, stamp.chamber.radius)
+
+
+def _button_worker(payload):
+    """Picklable worker: find button geometry for one stamp array."""
+    i, data = payload
+    _ensure_cv2_single_threaded()
+    stamp = Stamp(data, None, None, (0, 0), None)
+    stamp.findButton()
+    if stamp.button is None or stamp.button.blankFlag:
+        return i, None
+    return i, (
+        stamp.button.center,
+        stamp.button.disk_radius,
+        stamp.button.annulus_radii,
+    )
+
+
+def _stamp_process_pool(max_workers: int) -> ProcessPoolExecutor:
+    """Process pool using spawn to avoid fork deadlocks under threaded parents (e.g. pytest)."""
+    return ProcessPoolExecutor(
+        max_workers=max_workers,
+        mp_context=mp.get_context("spawn"),
+    )
 
 
 class ChipImage:
@@ -217,35 +271,80 @@ class ChipImage:
                     'Invalid feature name. Choices are "chamber", "button", or "all".'
                 )
 
-    def findChambers(self, coerce_center=False):
+    def findChambers(self, coerce_center=False, n_jobs=-1):
         """
         Performs chamber finding for each of the Stamps in the ChipImage. Uses a Hough transform.
 
         Arguments:
-            None
+            (bool) coerce_center: if True, place chamber at stamp center with fixed radius
+            (int) n_jobs: worker processes (-1 = all CPUs, 1 = serial)
 
         Returns:
             None
 
         """
 
-        for c in tqdm(self.stamps.flatten(), desc="Finding chambers", leave=False):
-            c.findChamber(coerce_center=coerce_center)
+        stamps = list(self.stamps.flatten())
+        workers = _resolve_n_jobs(n_jobs)
+        if workers <= 1:
+            for c in tqdm(stamps, desc="Finding chambers", leave=False):
+                c.findChamber(coerce_center=coerce_center)
+            return
 
-    def findButtons(self):
+        payloads = [(i, s.data, coerce_center) for i, s in enumerate(stamps)]
+        chunksize = max(1, len(payloads) // (workers * 4))
+        with _stamp_process_pool(workers) as executor:
+            results = list(
+                tqdm(
+                    executor.map(_chamber_worker, payloads, chunksize=chunksize),
+                    total=len(payloads),
+                    desc="Finding chambers",
+                    leave=False,
+                )
+            )
+        for i, geom in results:
+            if geom is None:
+                stamps[i].chamber = Chamber.BlankChamber()
+            else:
+                center, radius = geom
+                stamps[i].defineChamber(center, radius)
+
+    def findButtons(self, n_jobs=-1):
         """
-        Performs button finding for each of the Stamps in the ChipImage. Uses a Hough transform.
+        Performs button finding for each of the Stamps in the ChipImage.
 
         Arguments:
-            None
+            (int) n_jobs: worker processes (-1 = all CPUs, 1 = serial)
 
         Returns:
             None
 
         """
 
-        for c in tqdm(self.stamps.flatten(), desc="Finding buttons", leave=False):
-            c.findButton()
+        stamps = list(self.stamps.flatten())
+        workers = _resolve_n_jobs(n_jobs)
+        if workers <= 1:
+            for c in tqdm(stamps, desc="Finding buttons", leave=False):
+                c.findButton()
+            return
+
+        payloads = [(i, s.data) for i, s in enumerate(stamps)]
+        chunksize = max(1, len(payloads) // (workers * 4))
+        with _stamp_process_pool(workers) as executor:
+            results = list(
+                tqdm(
+                    executor.map(_button_worker, payloads, chunksize=chunksize),
+                    total=len(payloads),
+                    desc="Finding buttons",
+                    leave=False,
+                )
+            )
+        for i, geom in results:
+            if geom is None:
+                stamps[i].button = Button.BlankButton()
+            else:
+                center, disk_radius, annulus_radii = geom
+                stamps[i].defineButton(center, disk_radius, annulus_radii)
 
     def summarize(self):
         """
@@ -459,7 +558,7 @@ class Stamp:
             annulus_mask,
             b["center"],
             b["radius"],
-            (b["radius"], b["radius"]),
+            (b["radius"], o["radius"]),
         )
 
     def summarize(self):

--- a/src/mercury/processing/chip.py
+++ b/src/mercury/processing/chip.py
@@ -240,6 +240,8 @@ class ChipImage:
         Maps the chamber and/or button parameters to the target ChipImage, and generates the
         Chamber and/or Button objects for those features.
 
+        Deprecated for Processor hot paths; prefer mercury.processing.roi.RoiSet + quantify.
+
         Arguments:
             (ChipImage) target:
             (str) features; features to map ('chamber', 'button', 'all')
@@ -248,6 +250,12 @@ class ChipImage:
             None
 
         """
+        warnings.warn(
+            "ChipImage.mapto is deprecated for processing pipelines; "
+            "use mercury.processing.roi.RoiSet and quantify() instead.",
+            DeprecationWarning,
+            stacklevel=2,
+        )
 
         dims = self.device.dims
         indices = [(i, j) for i in range(dims.x) for j in range(dims.y)]

--- a/src/mercury/processing/roi.py
+++ b/src/mercury/processing/roi.py
@@ -1,0 +1,459 @@
+"""RoiSet-based stamp quantification and summary rendering.
+
+Masks in RoiSet use True = inside the ROI. Legacy circularSubsection /
+Chamber.disk masks use numpy.ma convention (True = ignore); convert with ``~``
+when exporting from a found ChipImage.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any, Dict, List, Optional, Sequence, Tuple, Union
+
+import numpy as np
+import pandas as pd
+import skimage.io
+
+from mercury.processing.chip import (
+    ChipImage,
+    annotateStamp,
+    _resolve_n_jobs,
+    _stamp_process_pool,
+)
+
+PathLike = Union[str, Path]
+
+CHAMBER_COLS = [
+    "median_chamber",
+    "sum_chamber",
+    "std_chamber",
+    "x_center_chamber",
+    "y_center_chamber",
+    "radius_chamber",
+]
+
+BUTTON_DISK_COLS = [
+    "median_button",
+    "summed_button",
+    "summed_button_BGsub",
+    "std_button",
+    "mean_button",
+    "x_button_center",
+    "y_button_center",
+    "radius_button_disk",
+]
+
+BUTTON_ANN_COLS = [
+    "median_button_annulus",
+    "summed_button_annulus_normed",
+    "std_button_annulus_localBG",
+    "mean_annulus",
+    "inner_radius_button_annulus",
+    "outer_radius_button_annulus",
+]
+
+BUTTON_COLS = BUTTON_DISK_COLS + BUTTON_ANN_COLS
+STAMP_META_COLS = ["xslice", "yslice", "id"]
+
+
+@dataclass
+class RoiSet:
+    """Geometry and inside-masks for quantifying stamps without Stamp objects."""
+
+    features: str
+    stamp_shape: Tuple[int, int]
+    indices: np.ndarray  # (N, 2)
+    ids: np.ndarray  # (N,)
+    row0: np.ndarray
+    row1: np.ndarray
+    col0: np.ndarray
+    col1: np.ndarray
+
+    chamber_blank: Optional[np.ndarray] = None
+    chamber_centers: Optional[np.ndarray] = None  # (N, 2)
+    chamber_radii: Optional[np.ndarray] = None
+    chamber_masks: Optional[np.ndarray] = None  # (N, H, W) True=inside
+
+    button_blank: Optional[np.ndarray] = None
+    button_centers: Optional[np.ndarray] = None
+    button_disk_radii: Optional[np.ndarray] = None
+    button_annulus_radii: Optional[np.ndarray] = None  # (N, 2) inner, outer
+    button_disk_masks: Optional[np.ndarray] = None
+    button_annulus_masks: Optional[np.ndarray] = None
+
+    @property
+    def n(self) -> int:
+        return int(len(self.indices))
+
+    @classmethod
+    def from_chip(cls, chip: ChipImage, features: str) -> "RoiSet":
+        """Build an RoiSet from a ChipImage after feature finding."""
+        if features not in ("chamber", "button", "all"):
+            raise ValueError("features must be 'chamber', 'button', or 'all'")
+        if chip.stamps is None:
+            raise ValueError("chip has no stamps; call stamp() and find* first")
+
+        stamps = list(chip.stamps.flatten())
+        n = len(stamps)
+        h, w = stamps[0].data.shape
+        indices = np.zeros((n, 2), dtype=int)
+        ids = np.empty(n, dtype=object)
+        row0 = np.zeros(n, dtype=int)
+        row1 = np.zeros(n, dtype=int)
+        col0 = np.zeros(n, dtype=int)
+        col1 = np.zeros(n, dtype=int)
+
+        want_chamber = features in ("chamber", "all")
+        want_button = features in ("button", "all")
+
+        chamber_blank = np.zeros(n, dtype=bool) if want_chamber else None
+        chamber_centers = np.full((n, 2), np.nan) if want_chamber else None
+        chamber_radii = np.full(n, np.nan) if want_chamber else None
+        chamber_masks = np.zeros((n, h, w), dtype=bool) if want_chamber else None
+
+        button_blank = np.zeros(n, dtype=bool) if want_button else None
+        button_centers = np.full((n, 2), np.nan) if want_button else None
+        button_disk_radii = np.full(n, np.nan) if want_button else None
+        button_annulus_radii = np.full((n, 2), np.nan) if want_button else None
+        button_disk_masks = np.zeros((n, h, w), dtype=bool) if want_button else None
+        button_annulus_masks = np.zeros((n, h, w), dtype=bool) if want_button else None
+
+        for i, s in enumerate(stamps):
+            indices[i] = s.index
+            ids[i] = s.id
+            row0[i] = s.slice[0].start
+            row1[i] = s.slice[0].stop
+            col0[i] = s.slice[1].start
+            col1[i] = s.slice[1].stop
+
+            if want_chamber:
+                ch = s.chamber
+                if ch is None or ch.blankFlag:
+                    chamber_blank[i] = True
+                else:
+                    chamber_blank[i] = False
+                    chamber_centers[i] = (ch.center[0], ch.center[1])
+                    chamber_radii[i] = ch.radius
+                    # ch.disk is ma-style (True=outside) → True=inside
+                    chamber_masks[i] = ~np.asarray(ch.disk, dtype=bool)
+
+            if want_button:
+                bt = s.button
+                if bt is None or bt.blankFlag:
+                    button_blank[i] = True
+                else:
+                    button_blank[i] = False
+                    button_centers[i] = (bt.center[0], bt.center[1])
+                    button_disk_radii[i] = bt.disk_radius
+                    button_annulus_radii[i] = (
+                        bt.annulus_radii[0],
+                        bt.annulus_radii[1],
+                    )
+                    button_disk_masks[i] = ~np.asarray(bt.disk, dtype=bool)
+                    button_annulus_masks[i] = ~np.asarray(bt.annulus, dtype=bool)
+
+        return cls(
+            features=features,
+            stamp_shape=(h, w),
+            indices=indices,
+            ids=ids,
+            row0=row0,
+            row1=row1,
+            col0=col0,
+            col1=col1,
+            chamber_blank=chamber_blank,
+            chamber_centers=chamber_centers,
+            chamber_radii=chamber_radii,
+            chamber_masks=chamber_masks,
+            button_blank=button_blank,
+            button_centers=button_centers,
+            button_disk_radii=button_disk_radii,
+            button_annulus_radii=button_annulus_radii,
+            button_disk_masks=button_disk_masks,
+            button_annulus_masks=button_annulus_masks,
+        )
+
+
+def stamps_from_chip(chip: ChipImage) -> np.ndarray:
+    """Stack stamp pixel data from a ChipImage to shape (N, H, W)."""
+    stamps = list(chip.stamps.flatten())
+    return np.stack([s.data for s in stamps], axis=0)
+
+
+def _open_image(path: PathLike) -> np.ndarray:
+    path = Path(path)
+    try:
+        import tifffile
+
+        return tifffile.memmap(str(path), mode="r")
+    except Exception:
+        return skimage.io.imread(path)
+
+
+def extract_stamps(
+    image: Union[PathLike, np.ndarray],
+    roi: RoiSet,
+) -> np.ndarray:
+    """Crop stamps to shape (N, H, W) using RoiSet slices."""
+    if not isinstance(image, np.ndarray):
+        img = _open_image(image)
+    else:
+        img = image
+
+    h, w = roi.stamp_shape
+    n = roi.n
+    out = np.empty((n, h, w), dtype=img.dtype)
+    for i in range(n):
+        out[i] = img[roi.row0[i] : roi.row1[i], roi.col0[i] : roi.col1[i]]
+    return out
+
+
+def _masked_sum(stamps: np.ndarray, inside: np.ndarray) -> np.ndarray:
+    return (stamps.astype(np.float64) * inside).sum(axis=(1, 2))
+
+
+def _masked_count(inside: np.ndarray) -> np.ndarray:
+    return inside.reshape(inside.shape[0], -1).sum(axis=1).astype(np.float64)
+
+
+def _masked_mean(stamps: np.ndarray, inside: np.ndarray) -> np.ndarray:
+    counts = _masked_count(inside)
+    sums = _masked_sum(stamps, inside)
+    out = np.full(stamps.shape[0], np.nan, dtype=np.float64)
+    np.divide(sums, counts, out=out, where=counts > 0)
+    return out
+
+
+def _masked_std(stamps: np.ndarray, inside: np.ndarray) -> np.ndarray:
+    """Population std (ddof=0), matching numpy.ma.std default."""
+    counts = _masked_count(inside)
+    means = _masked_mean(stamps, inside)
+    stamps_f = stamps.astype(np.float64)
+    diff2 = (stamps_f - means[:, None, None]) ** 2
+    ssq = (diff2 * inside).sum(axis=(1, 2))
+    out = np.full(stamps.shape[0], np.nan, dtype=np.float64)
+    np.sqrt(np.divide(ssq, counts, where=counts > 0), out=out, where=counts > 0)
+    out[counts <= 0] = np.nan
+    return out
+
+
+def _masked_median_loop(stamps: np.ndarray, inside: np.ndarray) -> np.ndarray:
+    n = stamps.shape[0]
+    out = np.full(n, np.nan, dtype=np.float64)
+    for i in range(n):
+        pix = stamps[i][inside[i]]
+        if pix.size:
+            out[i] = np.median(pix)
+    return out
+
+
+def _nan_cols(cols: Sequence[str], n: int) -> Dict[str, np.ndarray]:
+    return {c: np.full(n, np.nan) for c in cols}
+
+
+def _quantify_chamber(stamps: np.ndarray, roi: RoiSet) -> Dict[str, np.ndarray]:
+    n = roi.n
+    out = _nan_cols(CHAMBER_COLS, n)
+    blank = roi.chamber_blank
+    valid = ~blank
+    if not valid.any():
+        return out
+
+    inside = roi.chamber_masks[valid]
+    sub = stamps[valid]
+    med = _masked_median_loop(sub, inside)
+    sm = _masked_sum(sub, inside)
+    sd = _masked_std(sub, inside)
+
+    out["median_chamber"][valid] = med.astype(int)
+    out["sum_chamber"][valid] = sm.astype(int)
+    out["std_chamber"][valid] = sd.astype(int)
+    out["x_center_chamber"][valid] = roi.chamber_centers[valid, 0]
+    out["y_center_chamber"][valid] = roi.chamber_centers[valid, 1]
+    out["radius_chamber"][valid] = roi.chamber_radii[valid]
+    return out
+
+
+def _quantify_button(stamps: np.ndarray, roi: RoiSet) -> Dict[str, np.ndarray]:
+    n = roi.n
+    out = _nan_cols(BUTTON_COLS, n)
+    blank = roi.button_blank
+    valid = ~blank
+    if not valid.any():
+        return out
+
+    disk_in = roi.button_disk_masks[valid]
+    ann_in = roi.button_annulus_masks[valid]
+    sub = stamps[valid]
+
+    med_d = _masked_median_loop(sub, disk_in)
+    sum_d = _masked_sum(sub, disk_in)
+    std_d = _masked_std(sub, disk_in)
+    mean_d = _masked_mean(sub, disk_in)
+
+    med_a = _masked_median_loop(sub, ann_in)
+    sum_a = _masked_sum(sub, ann_in)
+    std_a = _masked_std(sub, ann_in)
+    mean_a = _masked_mean(sub, ann_in)
+
+    count_d = _masked_count(disk_in)
+    count_a = _masked_count(ann_in)
+    ratio = np.divide(count_a, count_d, out=np.full_like(count_a, np.nan), where=count_d > 0)
+    sum_a_normed = np.divide(
+        sum_a, ratio, out=np.full_like(sum_a, np.nan), where=np.isfinite(ratio) & (ratio > 0)
+    )
+    sum_bgsub = sum_d - sum_a_normed
+
+    out["median_button"][valid] = med_d.astype(int)
+    out["summed_button"][valid] = sum_d.astype(int)
+    out["summed_button_BGsub"][valid] = sum_bgsub.astype(int)
+    out["std_button"][valid] = std_d.astype(int)
+    out["mean_button"][valid] = mean_d.astype(int)
+    out["x_button_center"][valid] = roi.button_centers[valid, 0]
+    out["y_button_center"][valid] = roi.button_centers[valid, 1]
+    out["radius_button_disk"][valid] = roi.button_disk_radii[valid]
+
+    out["median_button_annulus"][valid] = med_a.astype(int)
+    out["summed_button_annulus_normed"][valid] = sum_a_normed.astype(int)
+    out["std_button_annulus_localBG"][valid] = std_a.astype(int)
+    out["mean_annulus"][valid] = mean_a.astype(int)
+    out["inner_radius_button_annulus"][valid] = roi.button_annulus_radii[valid, 0]
+    out["outer_radius_button_annulus"][valid] = roi.button_annulus_radii[valid, 1]
+    return out
+
+
+def quantify(
+    stamps_or_path: Union[PathLike, np.ndarray],
+    roi: RoiSet,
+    features: Optional[str] = None,
+) -> pd.DataFrame:
+    """Quantify stamps with an RoiSet. Accepts a stamp tensor or image path."""
+    features = features or roi.features
+    if isinstance(stamps_or_path, np.ndarray) and stamps_or_path.ndim == 3:
+        stamps = stamps_or_path
+    else:
+        stamps = extract_stamps(stamps_or_path, roi)
+
+    if stamps.shape[0] != roi.n:
+        raise ValueError(f"stamp count {stamps.shape[0]} != roi.n {roi.n}")
+
+    records: Dict[str, Any] = {}
+    if features in ("chamber", "all"):
+        if roi.chamber_masks is None:
+            raise ValueError("RoiSet has no chamber masks")
+        records.update(_quantify_chamber(stamps, roi))
+    if features in ("button", "all"):
+        if roi.button_disk_masks is None:
+            raise ValueError("RoiSet has no button masks")
+        records.update(_quantify_button(stamps, roi))
+
+    # Stamp metadata (match ChipImage.summarize / Stamp.summarize)
+    xslice = [
+        (int(roi.row0[i]), int(roi.row1[i])) for i in range(roi.n)
+    ]
+    yslice = [
+        (int(roi.col0[i]), int(roi.col1[i])) for i in range(roi.n)
+    ]
+    records["xslice"] = xslice
+    records["yslice"] = yslice
+    records["id"] = list(roi.ids)
+
+    idx = pd.MultiIndex.from_arrays(
+        [roi.indices[:, 0], roi.indices[:, 1]], names=["x", "y"]
+    )
+    df = pd.DataFrame(records, index=idx)
+    return df.sort_index()
+
+
+def render_summary(
+    stamps: np.ndarray,
+    roi: RoiSet,
+    features: Optional[str] = None,
+    metrics: Optional[pd.DataFrame] = None,
+) -> np.ndarray:
+    """Annotate stamps from RoiSet geometry and stitch into a summary image."""
+    features = features or roi.features
+    if stamps.shape[0] != roi.n:
+        raise ValueError(f"stamp count {stamps.shape[0]} != roi.n {roi.n}")
+
+    # Grid layout from index extent (1-based indices as in ChipImage)
+    xs = roi.indices[:, 0]
+    ys = roi.indices[:, 1]
+    xdim = int(xs.max())
+    ydim = int(ys.max())
+    h, w = roi.stamp_shape
+    # annotateStamp adds 1px border → (h+2, w+2)
+    tile_h, tile_w = h + 2, w + 2
+    tiles = np.empty((xdim, ydim), dtype=object)
+
+    metrics_by_index = None
+    if metrics is not None:
+        metrics_by_index = metrics
+
+    for i in range(roi.n):
+        ix, iy = int(roi.indices[i, 0]) - 1, int(roi.indices[i, 1]) - 1
+        circles: List = []
+        val = ""
+
+        if features in ("chamber", "all") and roi.chamber_blank is not None:
+            if not roi.chamber_blank[i]:
+                cx, cy = roi.chamber_centers[i]
+                rad = int(roi.chamber_radii[i])
+                circles.append([rad, (int(cx), int(cy))])
+
+        if features in ("button", "all") and roi.button_blank is not None:
+            if not roi.button_blank[i]:
+                cx, cy = roi.button_centers[i]
+                c = (int(cx), int(cy))
+                circles.append([int(roi.button_disk_radii[i]), c])
+                circles.append([int(roi.button_annulus_radii[i, 1]), c])
+                if metrics_by_index is not None:
+                    try:
+                        row = metrics_by_index.loc[(roi.indices[i, 0], roi.indices[i, 1])]
+                        bg = row.get("summed_button_BGsub", np.nan)
+                        ann = row.get("summed_button_annulus_normed", np.nan)
+                        if pd.notna(bg) and pd.notna(ann):
+                            val = "{}, {}".format(int(bg), int(ann))
+                    except KeyError:
+                        pass
+
+        index = "{}.{} | {}".format(roi.indices[i, 0], roi.indices[i, 1], roi.ids[i])
+        tiles[ix, iy] = annotateStamp(stamps[i], circles, index, val)
+
+    # Fill any missing grid slots with zeros (should not happen for full chips)
+    for ix in range(xdim):
+        for iy in range(ydim):
+            if tiles[ix, iy] is None:
+                tiles[ix, iy] = np.zeros((tile_h, tile_w), dtype=stamps.dtype)
+
+    arr = np.empty((xdim, ydim, tile_h, tile_w), dtype=stamps.dtype)
+    for ix in range(xdim):
+        for iy in range(ydim):
+            arr[ix, iy] = tiles[ix, iy]
+    return ChipImage.stitch2D(arr)
+
+
+def _quantify_image_worker(payload):
+    """Picklable worker: quantify one image path with a shared RoiSet."""
+    path, roi, features = payload
+    return quantify(path, roi, features=features)
+
+
+def quantify_images(
+    paths: Sequence[PathLike],
+    roi: RoiSet,
+    features: Optional[str] = None,
+    n_jobs: int = 1,
+) -> List[pd.DataFrame]:
+    """Quantify many images with one RoiSet; optional process pool over images."""
+    features = features or roi.features
+    workers = _resolve_n_jobs(n_jobs)
+    paths = list(paths)
+    if workers <= 1 or len(paths) <= 1:
+        return [quantify(p, roi, features=features) for p in paths]
+
+    payloads = [(p, roi, features) for p in paths]
+    chunksize = max(1, len(payloads) // (workers * 4))
+    with _stamp_process_pool(workers) as executor:
+        return list(executor.map(_quantify_image_worker, payloads, chunksize=chunksize))

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -1,6 +1,12 @@
 import os
+import sys
 from pathlib import Path
 import pytest
+
+# Allow `import processing_compare` and other test-local helpers.
+_TEST_DIR = Path(__file__).resolve().parent
+if str(_TEST_DIR) not in sys.path:
+    sys.path.insert(0, str(_TEST_DIR))
 
 
 @pytest.fixture(scope="session")

--- a/test/processing_compare.py
+++ b/test/processing_compare.py
@@ -1,0 +1,147 @@
+"""Reusable helpers for processing pre/post regression comparisons."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Iterable, Sequence, Union
+
+import matplotlib.pyplot as plt
+import numpy as np
+import pandas as pd
+
+from mercury.processing.chip import ChipImage
+from mercury.processing.experiment import Device, make_dummy_pinlist
+
+PathLike = Union[str, Path]
+
+DEFAULT_IMAGE = Path(
+    "/home/jzhang/Documents/scope_data/20260730/bgsub_images/"
+    "2026-07-30_15-02-00_d2_aura_cyan_2_5_sensitivity_2x2_1_button_quant.tif"
+)
+DEFAULT_CORNERS = [(387, 610), (6616, 640), (359, 6944), (6603, 6965)]
+DEVICE_DIMS = (32, 56)
+
+BUTTON_GEOMETRY_COLS = (
+    "x_button_center",
+    "y_button_center",
+    "radius_button_disk",
+)
+BUTTON_VALUE_COLS = ("summed_button_BGsub",) + BUTTON_GEOMETRY_COLS
+
+
+def make_chip(
+    image: PathLike,
+    corners: Sequence[tuple],
+    dims: tuple[int, int] = DEVICE_DIMS,
+) -> ChipImage:
+    """Build a stamped ChipImage with a dummy pinlist."""
+    image = Path(image)
+    device = Device(setup="s1", dname="d1", dims=dims)
+    device.pinlist = make_dummy_pinlist({i: f"block{i}" for i in range(1, 5)})
+    chip = ChipImage(device, image, list(corners))
+    chip.stamp()
+    return chip
+
+
+def run_feature_find(
+    chip: ChipImage,
+    feature: str = "button",
+    n_jobs: int = 1,
+    coerce_chamber_center: bool = False,
+) -> pd.DataFrame:
+    """Run chamber and/or button finding and return summarize()."""
+    if feature == "button":
+        chip.findButtons(n_jobs=n_jobs)
+    elif feature == "chamber":
+        chip.findChambers(coerce_center=coerce_chamber_center, n_jobs=n_jobs)
+    elif feature == "all":
+        chip.findChambers(coerce_center=coerce_chamber_center, n_jobs=n_jobs)
+        chip.findButtons(n_jobs=n_jobs)
+    else:
+        raise ValueError("feature must be 'button', 'chamber', or 'all'")
+    return chip.summarize()
+
+
+def compare_summaries(
+    baseline_df: pd.DataFrame,
+    candidate_df: pd.DataFrame,
+    value_cols: Iterable[str],
+    *,
+    atol: float = 0.0,
+    rtol: float = 0.0,
+) -> pd.DataFrame:
+    """Align on (x, y) and assert numeric agreement on value_cols.
+
+    Returns the outer-joined frame with ``_baseline`` / ``_candidate`` suffixes
+    for columns that appear in both inputs (useful for plotting).
+    """
+    value_cols = list(value_cols)
+    assert baseline_df.index.equals(candidate_df.index), "summary indices differ"
+
+    for col in value_cols:
+        assert col in baseline_df.columns, f"missing baseline column: {col}"
+        assert col in candidate_df.columns, f"missing candidate column: {col}"
+
+        b = baseline_df[col]
+        c = candidate_df[col]
+        b_null = b.isna()
+        c_null = c.isna()
+        assert (b_null == c_null).all(), f"null mask mismatch for {col}"
+
+        valid = ~b_null
+        if not valid.any():
+            continue
+        np.testing.assert_allclose(
+            c.loc[valid].to_numpy(dtype=float),
+            b.loc[valid].to_numpy(dtype=float),
+            atol=atol,
+            rtol=rtol,
+            err_msg=f"mismatch on {col}",
+        )
+
+    return baseline_df.join(candidate_df, lsuffix="_baseline", rsuffix="_candidate")
+
+
+def plot_unity_scatter(
+    baseline_df: pd.DataFrame,
+    candidate_df: pd.DataFrame,
+    col: str,
+    outpath: PathLike,
+    *,
+    title: str | None = None,
+    xlabel: str | None = None,
+    ylabel: str | None = None,
+) -> Path:
+    """Scatter candidate vs baseline for ``col`` with a y=x unity line."""
+    outpath = Path(outpath)
+    outpath.parent.mkdir(parents=True, exist_ok=True)
+
+    x = baseline_df[col].to_numpy(dtype=float)
+    y = candidate_df[col].to_numpy(dtype=float)
+    mask = np.isfinite(x) & np.isfinite(y)
+    x, y = x[mask], y[mask]
+
+    if len(x) < 2:
+        r = float("nan")
+    else:
+        r = float(np.corrcoef(x, y)[0, 1])
+
+    lo = float(np.nanmin([x.min(), y.min()])) if len(x) else 0.0
+    hi = float(np.nanmax([x.max(), y.max()])) if len(x) else 1.0
+    pad = 0.05 * (hi - lo) if hi > lo else 1.0
+    lims = (lo - pad, hi + pad)
+
+    fig, ax = plt.subplots(figsize=(6, 6))
+    ax.scatter(x, y, s=8, alpha=0.5, edgecolors="none")
+    ax.plot(lims, lims, "k--", lw=1, label="unity")
+    ax.set_xlim(lims)
+    ax.set_ylim(lims)
+    ax.set_aspect("equal", adjustable="box")
+    ax.set_xlabel(xlabel or f"baseline {col}")
+    ax.set_ylabel(ylabel or f"candidate {col}")
+    ax.set_title(title or f"{col} (r = {r:.6f})")
+    ax.legend(loc="upper left")
+    fig.tight_layout()
+    fig.savefig(outpath, dpi=150)
+    plt.close(fig)
+    return outpath

--- a/test/test_processing_parallel_find.py
+++ b/test/test_processing_parallel_find.py
@@ -1,11 +1,24 @@
 """Unit tests for parallel chamber/button finding across stamps."""
 
+from pathlib import Path
+
 import numpy as np
 import pandas as pd
+import pytest
 from skimage import io
 
 from mercury.processing.chip import ChipImage, Stamp, _resolve_n_jobs
 from mercury.processing.experiment import Device, read_pinlist
+
+from processing_compare import (
+    BUTTON_VALUE_COLS,
+    DEFAULT_CORNERS,
+    DEFAULT_IMAGE,
+    compare_summaries,
+    make_chip,
+    plot_unity_scatter,
+    run_feature_find,
+)
 
 
 def _make_pinlist(nx: int, ny: int) -> pd.DataFrame:
@@ -92,27 +105,29 @@ def test_find_chambers_serial_matches_parallel(tmp_path):
         assert s_serial.chamber.radius == s_parallel.chamber.radius
 
 
-def test_find_buttons_serial_matches_parallel(tmp_path):
-    nx, ny = 2, 2
-    stamps = np.empty((nx, ny), dtype=object)
-    for x in range(nx):
-        for y in range(ny):
-            stamps[x, y] = _bright_disk_stamp(
-                radius=12, center=(45 + x, 52 + y), peak=50000
-            )
+@pytest.mark.slow
+def test_find_buttons_serial_vs_parallel_real_image(tmp_path):
+    """Pre (n_jobs=1) vs post (n_jobs=2) button find on a real chip image."""
+    if not DEFAULT_IMAGE.exists():
+        pytest.skip(f"Regression image not found at {DEFAULT_IMAGE}")
 
-    chip_serial = _build_chip_with_stamps(tmp_path / "serial_btn", stamps)
-    chip_parallel = _build_chip_with_stamps(tmp_path / "parallel_btn", stamps)
+    chip_base = make_chip(DEFAULT_IMAGE, DEFAULT_CORNERS)
+    df_base = run_feature_find(chip_base, feature="button", n_jobs=1)
 
-    chip_serial.findButtons(n_jobs=1)
-    chip_parallel.findButtons(n_jobs=2)
+    chip_new = make_chip(DEFAULT_IMAGE, DEFAULT_CORNERS)
+    df_new = run_feature_find(chip_new, feature="button", n_jobs=2)
 
-    for s_serial, s_parallel in zip(
-        chip_serial.stamps.flatten(), chip_parallel.stamps.flatten()
-    ):
-        assert s_serial.button.blankFlag == s_parallel.button.blankFlag
-        if s_serial.button.blankFlag:
-            continue
-        assert s_serial.button.center == s_parallel.button.center
-        assert s_serial.button.disk_radius == s_parallel.button.disk_radius
-        assert s_serial.button.annulus_radii == s_parallel.button.annulus_radii
+    compare_summaries(df_base, df_new, BUTTON_VALUE_COLS, atol=0.0, rtol=0.0)
+
+    outpath = tmp_path / "button_find_parallel_unity.png"
+    plot_unity_scatter(
+        df_base,
+        df_new,
+        col="summed_button_BGsub",
+        outpath=outpath,
+        title="Button find: parallel vs serial (summed_button_BGsub)",
+        xlabel="serial n_jobs=1",
+        ylabel="parallel n_jobs=2",
+    )
+    assert outpath.exists() and outpath.stat().st_size > 0
+    print(f"Unity scatter written to {outpath}")

--- a/test/test_processing_parallel_find.py
+++ b/test/test_processing_parallel_find.py
@@ -1,0 +1,118 @@
+"""Unit tests for parallel chamber/button finding across stamps."""
+
+import numpy as np
+import pandas as pd
+from skimage import io
+
+from mercury.processing.chip import ChipImage, Stamp, _resolve_n_jobs
+from mercury.processing.experiment import Device, read_pinlist
+
+
+def _make_pinlist(nx: int, ny: int) -> pd.DataFrame:
+    rows = [
+        {"Indices": str((x + 1, y + 1)), "MutantID": f"m{x + 1}_{y + 1}"}
+        for x in range(nx)
+        for y in range(ny)
+    ]
+    return read_pinlist(pd.DataFrame(rows))
+
+
+def _build_chip_with_stamps(tmp_path, stamp_arrays):
+    """Build a ChipImage whose stamps are the given (nx, ny) stamp arrays."""
+    nx, ny = stamp_arrays.shape
+    h, w = stamp_arrays[0, 0].shape
+    assert h == ChipImage.stampWidth and w == ChipImage.stampWidth
+
+    tmp_path.mkdir(parents=True, exist_ok=True)
+
+    # Minimal raster large enough for a  nx x ny grid of non-overlapping stamps
+    img = np.zeros((ny * h + h, nx * w + w), dtype=np.uint16)
+    for x in range(nx):
+        for y in range(ny):
+            cy = h // 2 + y * h
+            cx = w // 2 + x * w
+            img[cy - h // 2 : cy + h // 2, cx - w // 2 : cx + w // 2] = stamp_arrays[x, y]
+
+    path = tmp_path / "synthetic_chip.tif"
+    io.imsave(path, img, check_contrast=False)
+
+    corners = (
+        (w // 2, h // 2),
+        (w // 2 + (nx - 1) * w, h // 2),
+        (w // 2, h // 2 + (ny - 1) * h),
+        (w // 2 + (nx - 1) * w, h // 2 + (ny - 1) * h),
+    )
+    device = Device(setup="s1", dname="d1", dims=(nx, ny))
+    device.pinlist = _make_pinlist(nx, ny)
+    chip = ChipImage(device, path, corners)
+    chip.stamp()
+    return chip
+
+
+def _bright_disk_stamp(radius: int, center=None, peak: int = 40000) -> np.ndarray:
+    import cv2
+
+    size = ChipImage.stampWidth
+    if center is None:
+        center = (size // 2, size // 2)
+    stamp = np.full((size, size), 1000, dtype=np.uint16)
+    cv2.circle(stamp, (int(center[0]), int(center[1])), radius, int(peak), -1)
+    return stamp
+
+
+def test_resolve_n_jobs():
+    assert _resolve_n_jobs(1) == 1
+    assert _resolve_n_jobs(4) == 4
+    assert _resolve_n_jobs(-1) >= 1
+
+
+def test_find_chambers_serial_matches_parallel(tmp_path):
+    nx, ny = 2, 2
+    stamps = np.empty((nx, ny), dtype=object)
+    for x in range(nx):
+        for y in range(ny):
+            # Offset slightly so Hough has a clear circle; radius in chamber search band
+            stamps[x, y] = _bright_disk_stamp(
+                radius=Stamp.chamberrad, center=(48 + x, 50 + y)
+            )
+
+    chip_serial = _build_chip_with_stamps(tmp_path / "serial", stamps)
+    chip_parallel = _build_chip_with_stamps(tmp_path / "parallel", stamps)
+
+    chip_serial.findChambers(n_jobs=1)
+    chip_parallel.findChambers(n_jobs=2)
+
+    for s_serial, s_parallel in zip(
+        chip_serial.stamps.flatten(), chip_parallel.stamps.flatten()
+    ):
+        assert s_serial.chamber.blankFlag == s_parallel.chamber.blankFlag
+        if s_serial.chamber.blankFlag:
+            continue
+        assert s_serial.chamber.center == s_parallel.chamber.center
+        assert s_serial.chamber.radius == s_parallel.chamber.radius
+
+
+def test_find_buttons_serial_matches_parallel(tmp_path):
+    nx, ny = 2, 2
+    stamps = np.empty((nx, ny), dtype=object)
+    for x in range(nx):
+        for y in range(ny):
+            stamps[x, y] = _bright_disk_stamp(
+                radius=12, center=(45 + x, 52 + y), peak=50000
+            )
+
+    chip_serial = _build_chip_with_stamps(tmp_path / "serial_btn", stamps)
+    chip_parallel = _build_chip_with_stamps(tmp_path / "parallel_btn", stamps)
+
+    chip_serial.findButtons(n_jobs=1)
+    chip_parallel.findButtons(n_jobs=2)
+
+    for s_serial, s_parallel in zip(
+        chip_serial.stamps.flatten(), chip_parallel.stamps.flatten()
+    ):
+        assert s_serial.button.blankFlag == s_parallel.button.blankFlag
+        if s_serial.button.blankFlag:
+            continue
+        assert s_serial.button.center == s_parallel.button.center
+        assert s_serial.button.disk_radius == s_parallel.button.disk_radius
+        assert s_serial.button.annulus_radii == s_parallel.button.annulus_radii

--- a/test/test_roi_mapping.py
+++ b/test/test_roi_mapping.py
@@ -1,0 +1,213 @@
+"""Tests for RoiSet export, quantify parity, and render_summary."""
+
+from __future__ import annotations
+
+import warnings
+
+import numpy as np
+import pandas as pd
+import pytest
+from skimage import io
+
+from mercury.processing.chip import ChipImage, Stamp
+from mercury.processing.experiment import Device, read_pinlist
+from mercury.processing.roi import (
+    BUTTON_COLS,
+    CHAMBER_COLS,
+    RoiSet,
+    extract_stamps,
+    quantify,
+    render_summary,
+    stamps_from_chip,
+)
+
+from processing_compare import (
+    BUTTON_VALUE_COLS,
+    DEFAULT_CORNERS,
+    DEFAULT_IMAGE,
+    compare_summaries,
+    make_chip,
+    plot_unity_scatter,
+    run_feature_find,
+)
+
+
+def _make_pinlist(nx: int, ny: int) -> pd.DataFrame:
+    rows = [
+        {"Indices": str((x + 1, y + 1)), "MutantID": f"m{x + 1}_{y + 1}"}
+        for x in range(nx)
+        for y in range(ny)
+    ]
+    return read_pinlist(pd.DataFrame(rows))
+
+
+def _bright_disk_stamp(radius: int, center=None, peak: int = 40000) -> np.ndarray:
+    import cv2
+
+    size = ChipImage.stampWidth
+    if center is None:
+        center = (size // 2, size // 2)
+    stamp = np.full((size, size), 1000, dtype=np.uint16)
+    cv2.circle(stamp, (int(center[0]), int(center[1])), radius, int(peak), -1)
+    return stamp
+
+
+def _build_chip_with_stamps(tmp_path, stamp_arrays):
+    nx, ny = stamp_arrays.shape
+    h, w = stamp_arrays[0, 0].shape
+    tmp_path.mkdir(parents=True, exist_ok=True)
+    img = np.zeros((ny * h + h, nx * w + w), dtype=np.uint16)
+    for x in range(nx):
+        for y in range(ny):
+            cy = h // 2 + y * h
+            cx = w // 2 + x * w
+            img[cy - h // 2 : cy + h // 2, cx - w // 2 : cx + w // 2] = stamp_arrays[x, y]
+    path = tmp_path / "synthetic_chip.tif"
+    io.imsave(path, img, check_contrast=False)
+    corners = (
+        (w // 2, h // 2),
+        (w // 2 + (nx - 1) * w, h // 2),
+        (w // 2, h // 2 + (ny - 1) * h),
+        (w // 2 + (nx - 1) * w, h // 2 + (ny - 1) * h),
+    )
+    device = Device(setup="s1", dname="d1", dims=(nx, ny))
+    device.pinlist = _make_pinlist(nx, ny)
+    chip = ChipImage(device, path, corners)
+    chip.stamp()
+    return chip
+
+
+def test_roisets_from_chip_chamber_masks(tmp_path):
+    nx, ny = 2, 2
+    stamps = np.empty((nx, ny), dtype=object)
+    for x in range(nx):
+        for y in range(ny):
+            stamps[x, y] = _bright_disk_stamp(
+                radius=Stamp.chamberrad, center=(48 + x, 50 + y)
+            )
+    chip = _build_chip_with_stamps(tmp_path / "ch", stamps)
+    chip.findChambers(n_jobs=1)
+
+    roi = RoiSet.from_chip(chip, features="chamber")
+    assert roi.n == 4
+    assert roi.chamber_masks.shape == (4, *roi.stamp_shape)
+    assert roi.button_disk_masks is None
+
+    flat = list(chip.stamps.flatten())
+    for i, s in enumerate(flat):
+        if s.chamber.blankFlag:
+            assert roi.chamber_blank[i]
+            continue
+        assert not roi.chamber_blank[i]
+        expected_inside = ~np.asarray(s.chamber.disk, dtype=bool)
+        np.testing.assert_array_equal(roi.chamber_masks[i], expected_inside)
+        p = Stamp.circularSubsection(
+            s.data, s.chamber.center, s.chamber.radius
+        )
+        np.testing.assert_array_equal(roi.chamber_masks[i], ~p["mask"])
+
+
+def test_quantify_matches_summarize_synthetic_buttons(tmp_path):
+    nx, ny = 2, 2
+    stamps = np.empty((nx, ny), dtype=object)
+    for x in range(nx):
+        for y in range(ny):
+            stamps[x, y] = _bright_disk_stamp(
+                radius=12, center=(45 + x, 52 + y), peak=50000
+            )
+    chip = _build_chip_with_stamps(tmp_path / "btn", stamps)
+    chip.findButtons(n_jobs=1)
+
+    legacy = chip.summarize()
+    roi = RoiSet.from_chip(chip, features="button")
+    got = quantify(stamps_from_chip(chip), roi, features="button")
+
+    compare_summaries(legacy, got, BUTTON_COLS, atol=1.0, rtol=0.0)
+
+
+def test_quantify_matches_summarize_synthetic_chambers(tmp_path):
+    nx, ny = 2, 2
+    stamps = np.empty((nx, ny), dtype=object)
+    for x in range(nx):
+        for y in range(ny):
+            stamps[x, y] = _bright_disk_stamp(
+                radius=Stamp.chamberrad, center=(48 + x, 50 + y)
+            )
+    chip = _build_chip_with_stamps(tmp_path / "ch2", stamps)
+    chip.findChambers(n_jobs=1)
+
+    legacy = chip.summarize()
+    roi = RoiSet.from_chip(chip, features="chamber")
+    got = quantify(stamps_from_chip(chip), roi, features="chamber")
+
+    compare_summaries(legacy, got, CHAMBER_COLS, atol=1.0, rtol=0.0)
+
+
+def test_render_summary_all_features(tmp_path):
+    nx, ny = 2, 2
+    stamps_arr = np.empty((nx, ny), dtype=object)
+    for x in range(nx):
+        for y in range(ny):
+            stamps_arr[x, y] = _bright_disk_stamp(
+                radius=Stamp.chamberrad, center=(50, 50)
+            )
+    chip = _build_chip_with_stamps(tmp_path / "all", stamps_arr)
+    chip.findChambers(coerce_center=True, n_jobs=1)
+    # Define buttons manually at center for render test
+    for s in chip.stamps.flatten():
+        s.defineButton((50, 50), 12, (12, 24))
+
+    roi = RoiSet.from_chip(chip, features="all")
+    stamps = stamps_from_chip(chip)
+    metrics = quantify(stamps, roi, features="all")
+    img = render_summary(stamps, roi, features="all", metrics=metrics)
+    assert img.ndim == 2
+    assert img.shape[0] > ChipImage.stampWidth
+    assert img.shape[1] > ChipImage.stampWidth
+
+
+@pytest.mark.slow
+def test_quantify_vs_mapto_real_image(tmp_path):
+    """Legacy mapto+summarize vs RoiSet quantify on real chip image."""
+    if not DEFAULT_IMAGE.exists():
+        pytest.skip(f"Regression image not found at {DEFAULT_IMAGE}")
+
+    chip_ref = make_chip(DEFAULT_IMAGE, DEFAULT_CORNERS)
+    run_feature_find(chip_ref, feature="button", n_jobs=2)
+    roi = RoiSet.from_chip(chip_ref, features="button")
+
+    # Legacy map path onto a fresh chip of the same image
+    chip_legacy = make_chip(DEFAULT_IMAGE, DEFAULT_CORNERS)
+    with warnings.catch_warnings():
+        warnings.simplefilter("ignore", DeprecationWarning)
+        chip_ref.mapto(chip_legacy, features="button")
+    df_legacy = chip_legacy.summarize()
+
+    df_new = quantify(DEFAULT_IMAGE, roi, features="button")
+    compare_summaries(df_legacy, df_new, BUTTON_VALUE_COLS, atol=1.0, rtol=0.0)
+
+    outpath = tmp_path / "roi_quantify_unity.png"
+    plot_unity_scatter(
+        df_legacy,
+        df_new,
+        col="summed_button_BGsub",
+        outpath=outpath,
+        title="RoiSet quantify vs mapto (summed_button_BGsub)",
+        xlabel="mapto + summarize",
+        ylabel="RoiSet quantify",
+    )
+    assert outpath.exists() and outpath.stat().st_size > 0
+
+
+def test_extract_stamps_matches_chip(tmp_path):
+    nx, ny = 2, 2
+    stamps = np.empty((nx, ny), dtype=object)
+    for x in range(nx):
+        for y in range(ny):
+            stamps[x, y] = _bright_disk_stamp(12, center=(50, 50))
+    chip = _build_chip_with_stamps(tmp_path / "ex", stamps)
+    chip.findButtons(n_jobs=1)
+    roi = RoiSet.from_chip(chip, features="button")
+    extracted = extract_stamps(chip.data_ref, roi)
+    stacked = stamps_from_chip(chip)
+    np.testing.assert_array_equal(extracted, stacked)


### PR DESCRIPTION
Increased throughput of button/chamber finding via parallelization over stamps without touching the feature finding logic itself. I verified unity between the original serial and new parallelized button finding on a test button quant image (see plot below).

<img width="900" height="900" alt="button_find_parallel_unity" src="https://github.com/user-attachments/assets/a4bfddcf-37ae-44dc-a728-454aaea9f2ad" />

Also improved the performance of feature mapping onto a stack of target images through vectorized quantification of means, sums, and stds over the stamp dimension and parallel processing over the target image dimension. This required building a new dataclass, implemented in `processing/roi.py`. 